### PR TITLE
Correctly detect Windows PowerShell in Initialize-TestEnvironment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Correctly detect Windows PowerShell in `Initialize-TestEnvironment`.
+
+## [0.5.0] - 2019-12-12
+
+### Fixed
+
 - Now skipping isAdmin on non-windows (because creds works differently)
 - Moving spellcheck out of the tests
 - Updating ScriptFiles tests to get different module base when from module or from project path

--- a/build.yaml
+++ b/build.yaml
@@ -12,7 +12,7 @@ CopyDirectories:
   - Config
 # SemVer: '1.2.3'
 # Suffix to add to Root module PSM1 after merge (here, the Set-Alias exporting IB tasks)
-suffix: suffix.ps1
+# suffix: suffix.ps1
 VersionedOutputDirectory: true
 
 ####################################################

--- a/source/Public/Initialize-TestEnvironment.ps1
+++ b/source/Public/Initialize-TestEnvironment.ps1
@@ -188,7 +188,7 @@ function Initialize-TestEnvironment
     if ($TestType -ieq 'Integration')
     {
         # Making sure setting up the LCM & Machine Path makes sense...
-        if ($isWindows -and
+        if (($IsWindows -or $PSEdition -eq 'Desktop') -and
             ($Principal = [Security.Principal.WindowsPrincipal]::new([Security.Principal.WindowsIdentity]::GetCurrent())) -and
             $Principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
         )

--- a/tests/Unit/Public/Initialize-TestEnvironment.Tests.ps1
+++ b/tests/Unit/Public/Initialize-TestEnvironment.Tests.ps1
@@ -116,7 +116,7 @@ InModuleScope $ProjectName {
                         $PSBoundParameters.ContainsKey('Machine') -eq $true
                     } -Exactly -Times 1 -Scope It
 
-                    if ($isWindows -and
+                    if (($IsWindows -or $PSEdition -eq 'Desktop') -and
                         ($Principal = [Security.Principal.WindowsPrincipal]::new([Security.Principal.WindowsIdentity]::GetCurrent())) -and
                         $Principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
                     )


### PR DESCRIPTION
The resolves that `$IsWindows` does not exist in Windows PowerShell.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/dscresource.test/16)
<!-- Reviewable:end -->
