### PR TITLE
Suppress Output from Initialize-DscTestLcm - Fixes #21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Temporarily remove Admin-check in `Initialize-TestEnvironment`.
+- Suppress output from function `Initialize-DscTestLcm`.
 
 ## [0.5.1] - 2019-12-13
 

--- a/source/Private/Initialize-DscTestLcm.ps1
+++ b/source/Private/Initialize-DscTestLcm.ps1
@@ -72,7 +72,7 @@ function Initialize-DscTestLcm
 
     Invoke-Command -ScriptBlock ([scriptblock]::Create($configurationMetadata)) -NoNewScope
 
-    LocalConfigurationManagerConfiguration -OutputPath $disableConsistencyMofPath
+    $null = LocalConfigurationManagerConfiguration -OutputPath $disableConsistencyMofPath
 
     Set-DscLocalConfigurationManager -Path $disableConsistencyMofPath -Force -Verbose
     $null = Remove-Item -LiteralPath $disableConsistencyMofPath -Recurse -Force -Confirm:$false


### PR DESCRIPTION
This PR suppresses output from Initialize-DscTestLcm from the line https://github.com/dsccommunity/DscResource.Test/blob/fca8e43aa5cee8ae095d43282dcb6a1102bfdf44/source/Private/Initialize-DscTestLcm.ps1#L75

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/dscresource.test/22)
<!-- Reviewable:end -->
