### PR TITLE
PSSAResource and ResourceSchema Tests: Move Init code into Describe Block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Moved init code into Describe Block for PSSAResource and ResourceSchema Tests
+
 ## [0.11.0] - 2019-12-29
 
 ### Added

--- a/source/Tests/QA/PSSAResource.common.Tests.ps1
+++ b/source/Tests/QA/PSSAResource.common.Tests.ps1
@@ -12,60 +12,58 @@ param (
     $ExcludeSourceFile
 )
 
-
-if ($PSVersionTable.PSVersion.Major -lt 5)
-{
-    Write-Warning -Message 'PS Script Analyzer can not run on this platform. Please run tests on a machine with WMF 5.0+.'
-    return
-}
-
-<#
-    PSSA = PS Script Analyzer
-
-    The following PSSA tests will always fail if any violations are found:
-    - Common Tests - Error-Level Script Analyzer Rules
-    - Common Tests - Custom Script Analyzer Rules
-
-    The following PSSA tests will only fail if a violation is found and
-    a matching option is found in the opt-in file.
-    - Common Tests - Required Script Analyzer Rules
-    - Common Tests - Flagged Script Analyzer Rules
-    - Common Tests - New Error-Level Script Analyzer Rules
-    - Common Tests - Custom Script Analyzer Rules
-#>
-$RequiredPSSA = @(
-    'Common Tests - Required Script Analyzer Rules',
-    'RequiredPSSA'
-)
-$FlaggedPSSA = @(
-    'Common Tests - Flagged Script Analyzer Rules',
-    'FlaggedPSSA'
-)
-$NewErrorPSSA = @(
-    'Common Tests - New Error-Level Script Analyzer Rules',
-    'NewErrorPSSA'
-)
-$CustomPSSA = @(
-    'Common Tests - Custom Script Analyzer Rules',
-    'CustomPSSA',
-    'DscResource.AnalyzerRules'
-)
-
-
-$TestTestShouldBeSkippedParams = @{
-    Tag = $Tag
-    ExcludeTag = $ExcludeTag
-}
-
-$ShouldSkipRequiredPSSA = Test-TestShouldBeSkipped @TestTestShouldBeSkippedParams -TestNames $RequiredPSSA
-$ShouldSkipFlaggedPSSA  = Test-TestShouldBeSkipped @TestTestShouldBeSkippedParams -TestNames $FlaggedPSSA
-$ShouldSkipCustomPSSA   = Test-TestShouldBeSkipped @TestTestShouldBeSkippedParams -TestNames $CustomPSSA
-$ShouldSkipNewErrorPSSA = Test-TestShouldBeSkipped @TestTestShouldBeSkippedParams -TestNames $NewErrorPSSA
-
-$PSSA_rule_config = Get-StructuredObjectFromFile -Path (Join-Path (Get-CurrentModuleBase) 'Config/PSSA_rules_config.json')
-$DscResourceAnalyzerRulesModule = Import-Module DscResource.AnalyzerRules -PassThru -ErrorAction Stop
-
 Describe 'Common Tests - PS Script Analyzer on Resource Files' -Tag DscPSSA,'Common Tests - PS Script Analyzer on Resource Files' {
+
+    if ($PSVersionTable.PSVersion.Major -lt 5)
+    {
+        Write-Warning -Message 'PS Script Analyzer can not run on this platform. Please run tests on a machine with WMF 5.0+.'
+        return
+    }
+
+    <#
+        PSSA = PS Script Analyzer
+
+        The following PSSA tests will always fail if any violations are found:
+        - Common Tests - Error-Level Script Analyzer Rules
+        - Common Tests - Custom Script Analyzer Rules
+
+        The following PSSA tests will only fail if a violation is found and
+        a matching option is found in the opt-in file.
+        - Common Tests - Required Script Analyzer Rules
+        - Common Tests - Flagged Script Analyzer Rules
+        - Common Tests - New Error-Level Script Analyzer Rules
+        - Common Tests - Custom Script Analyzer Rules
+    #>
+    $RequiredPSSA = @(
+        'Common Tests - Required Script Analyzer Rules',
+        'RequiredPSSA'
+    )
+    $FlaggedPSSA = @(
+        'Common Tests - Flagged Script Analyzer Rules',
+        'FlaggedPSSA'
+    )
+    $NewErrorPSSA = @(
+        'Common Tests - New Error-Level Script Analyzer Rules',
+        'NewErrorPSSA'
+    )
+    $CustomPSSA = @(
+        'Common Tests - Custom Script Analyzer Rules',
+        'CustomPSSA',
+        'DscResource.AnalyzerRules'
+    )
+
+    $TestTestShouldBeSkippedParams = @{
+        Tag = $Tag
+        ExcludeTag = $ExcludeTag
+    }
+
+    $ShouldSkipRequiredPSSA = Test-TestShouldBeSkipped @TestTestShouldBeSkippedParams -TestNames $RequiredPSSA
+    $ShouldSkipFlaggedPSSA  = Test-TestShouldBeSkipped @TestTestShouldBeSkippedParams -TestNames $FlaggedPSSA
+    $ShouldSkipCustomPSSA   = Test-TestShouldBeSkipped @TestTestShouldBeSkippedParams -TestNames $CustomPSSA
+    $ShouldSkipNewErrorPSSA = Test-TestShouldBeSkipped @TestTestShouldBeSkippedParams -TestNames $NewErrorPSSA
+
+    $PSSA_rule_config = Get-StructuredObjectFromFile -Path (Join-Path (Get-CurrentModuleBase) 'Config/PSSA_rules_config.json')
+    $DscResourceAnalyzerRulesModule = Import-Module DscResource.AnalyzerRules -PassThru -ErrorAction Stop
 
     $dscResourcesPsm1Files = @(Get-ChildItem -Path $ModuleBase -Include *.psm1 -Recurse | WhereModuleFileNotExcluded)
 

--- a/source/Tests/QA/ResourceSchema.common.Tests.ps1
+++ b/source/Tests/QA/ResourceSchema.common.Tests.ps1
@@ -7,28 +7,29 @@ param (
     $SourceManifest
 )
 
-if ($isLinux -or $IsMacOS)
-{
-    $skipTests = $true
-    Write-Warning "xDscResourceDesigner module only works on Windows at the moment."
-    Write-Warning "Test-xDscResource & Test-xDscSchema will be skipped"
-}
-else
-{
-    $Principal = [Security.Principal.WindowsPrincipal]::new([Security.Principal.WindowsIdentity]::GetCurrent())
-    $isAdmin = $Principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
-    if ($isAdmin)
+Describe 'Common Tests - Script Resource Schema Validation' -Tag WindowsOnly {
+    if ($isLinux -or $IsMacOS)
     {
-        $skipTests = $false
+        $skipTests = $true
+        Write-Warning "xDscResourceDesigner module only works on Windows at the moment."
+        Write-Warning "Test-xDscResource & Test-xDscSchema will be skipped"
     }
     else
     {
-        Write-Warning "xDscResourceDesigner needs your session to be running elevated."
-        Write-Warning "Test-xDscResource & Test-xDscSchema will be skipped"
-        $skipTests = $true
+        $Principal = [Security.Principal.WindowsPrincipal]::new([Security.Principal.WindowsIdentity]::GetCurrent())
+        $isAdmin = $Principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+        if ($isAdmin)
+        {
+            $skipTests = $false
+        }
+        else
+        {
+            Write-Warning "xDscResourceDesigner needs your session to be running elevated."
+            Write-Warning "Test-xDscResource & Test-xDscSchema will be skipped"
+            $skipTests = $true
+        }
     }
-}
-Describe 'Common Tests - Script Resource Schema Validation' -Tag WindowsOnly {
+
     if ($isAdmin -and ($IsWindows -or $PSVersionTable.PSEdition -eq 'Desktop'))
     {
         Import-Module -Name xDscResourceDesigner -ErrorAction Stop


### PR DESCRIPTION
This PR moves the test initialisation code into the Describe block for the `PSSAResource` and `ResourceSchema` tests.

This is so that if these tests are filtered out in a test run, the initialisation code does not run.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/dscresource.test/54)
<!-- Reviewable:end -->
