### PR TITLE
Required PowerShell version lowered to v5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Moved init code into Describe Block for PSSAResource and ResourceSchema Tests
+- Required PowerShell version was lowered to v5.0 in the module manifest.
 
 ### Fixed
 

--- a/source/DscResource.Test.psd1
+++ b/source/DscResource.Test.psd1
@@ -25,7 +25,7 @@
     Description       = 'Testing DSC Resources against HQRM guidelines'
 
     # Minimum version of the PowerShell engine required by this module
-    PowerShellVersion = '5.1'
+    PowerShellVersion = '5.0'
 
     # Name of the PowerShell host required by this module
     # PowerShellHostName = ''


### PR DESCRIPTION
Required PowerShell version was lowered to v5.0 in the module manifest (issue #58).

- Fixes #58

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/dscresource.test/59)
<!-- Reviewable:end -->
