### PR TITLE
Update the cmdlet Initialize-TestEnvironment to support PS 5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Required PowerShell version was lowered to v5.0 in the module manifest.
+  - Update the cmdlet `Initialize-TestEnvironment` to allow setting up
+    the environment when run in PowerShell 5.0.
+  - Update the pipeline so the module will be tested on PowerShell 5.0 
+    (Microsoft-hosted agent running Windows Server 2012 R2).
 - Azure Pipelines will no longer trigger on changes to just the CHANGELOG.md.
 
 ## [0.11.1] - 2020-01-06

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -155,6 +155,44 @@ stages:
               summaryFileLocation: 'output/testResults/CodeCov*.xml'
               pathToSources: '$(Build.SourcesDirectory)/output/$(DscBuildVariable.RepositoryName)'
 
+      - job: test_windows_ps_5
+        pool:
+          vmImage: 'vs2015-win2012r2'
+        steps:
+          - task: DownloadBuildArtifacts@0
+            inputs:
+              buildType: 'current'
+              downloadType: 'single'
+              artifactName: 'output'
+              downloadPath: '$(Build.SourcesDirectory)'
+
+          - powershell: |
+              $repositoryOwner,$repositoryName = $env:BUILD_REPOSITORY_NAME -split '/'
+              echo "##vso[task.setvariable variable=RepositoryOwner;isOutput=true]$repositoryOwner"
+              echo "##vso[task.setvariable variable=RepositoryName;isOutput=true]$repositoryName"
+            name: DscBuildVariable
+
+          - task: PowerShell@2
+            name: Test
+            inputs:
+              filePath: './build.ps1'
+              arguments: '-tasks test'
+              pwsh: false
+
+          - task: PublishTestResults@2
+            condition: succeededOrFailed()
+            inputs:
+              testResultsFormat: 'NUnit'
+              testResultsFiles: 'output/testResults/NUnit*.xml'
+
+          # Publish code coverage results
+          - task: PublishCodeCoverageResults@1
+            condition: succeededOrFailed()
+            inputs:
+              codeCoverageTool: 'JaCoCo'
+              summaryFileLocation: 'output/testResults/CodeCov*.xml'
+              pathToSources: '$(Build.SourcesDirectory)/output/$(DscBuildVariable.RepositoryName)'
+
       - job: test_macos
         pool:
           vmImage: 'macos-latest'

--- a/source/Public/Initialize-TestEnvironment.ps1
+++ b/source/Public/Initialize-TestEnvironment.ps1
@@ -209,7 +209,7 @@ function Initialize-TestEnvironment
     if ($TestType -in ('Integration','All'))
     {
         # Making sure setting up the LCM & Machine Path makes sense...
-        if (($IsWindows -or $PSEdition -eq 'Desktop') -and
+        if (($IsWindows -or $PSEdition -eq 'Desktop' -or $PSVersionTable.PSVersion -lt [Version] '5.1') -and
             ($Principal = [Security.Principal.WindowsPrincipal]::new([Security.Principal.WindowsIdentity]::GetCurrent())) -and
             $Principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
         )

--- a/source/Public/Initialize-TestEnvironment.ps1
+++ b/source/Public/Initialize-TestEnvironment.ps1
@@ -208,8 +208,13 @@ function Initialize-TestEnvironment
 
     if ($TestType -in ('Integration','All'))
     {
-        # Making sure setting up the LCM & Machine Path makes sense...
-        if (($IsWindows -or $PSEdition -eq 'Desktop' -or $PSVersionTable.PSVersion -lt [Version] '5.1') -and
+        <#
+            Making sure setting up the LCM & Machine Path makes sense...
+
+            $PSEdition does not exist prior to PS5.1 so we need to evaluate the
+            version in $PSVersionTable too.
+        #>
+        if (($IsWindows -or $PSEdition -eq 'Desktop' -or $PSVersionTable.PSVersion -lt [System.Version] '5.1') -and
             ($Principal = [Security.Principal.WindowsPrincipal]::new([Security.Principal.WindowsIdentity]::GetCurrent())) -and
             $Principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
         )

--- a/tests/Unit/Private/Test-ConfigurationName.Tests.ps1
+++ b/tests/Unit/Private/Test-ConfigurationName.Tests.ps1
@@ -102,9 +102,15 @@ InModuleScope $ProjectName {
             '
 
                 $definition | Out-File -FilePath $mockScriptPath -Encoding utf8 -Force
+
+                <#
+                    It is not allowed to have a configuration name that contains
+                    a dash ('-') in PS5.0. Skipping this test if it is PS5.0.
+                #>
+                $skipTest = $PSVersionTable.PSVersion -lt [System.Version] '5.1'
             }
 
-            It 'Should return false' {
+            It 'Should return false' -Skip:$skipTest {
                 $result = Test-ConfigurationName -Path $mockScriptPath
                 $result | Should -BeFalse
             }

--- a/tests/Unit/Public/Initialize-TestEnvironment.Tests.ps1
+++ b/tests/Unit/Public/Initialize-TestEnvironment.Tests.ps1
@@ -116,7 +116,7 @@ InModuleScope $ProjectName {
                         $PSBoundParameters.ContainsKey('Machine') -eq $true
                     } -Exactly -Times 1 -Scope It
 
-                    if (($IsWindows -or $PSEdition -eq 'Desktop' -or $PSVersionTable.PSVersion -lt [Version] '5.1') -and
+                    if (($IsWindows -or $PSEdition -eq 'Desktop' -or $PSVersionTable.PSVersion -lt [System.Version] '5.1') -and
                         ($Principal = [Security.Principal.WindowsPrincipal]::new([Security.Principal.WindowsIdentity]::GetCurrent())) -and
                         $Principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
                     )

--- a/tests/Unit/Public/Initialize-TestEnvironment.Tests.ps1
+++ b/tests/Unit/Public/Initialize-TestEnvironment.Tests.ps1
@@ -116,7 +116,7 @@ InModuleScope $ProjectName {
                         $PSBoundParameters.ContainsKey('Machine') -eq $true
                     } -Exactly -Times 1 -Scope It
 
-                    if (($IsWindows -or $PSEdition -eq 'Desktop') -and
+                    if (($IsWindows -or $PSEdition -eq 'Desktop' -or $PSVersionTable.PSVersion -lt [Version] '5.1') -and
                         ($Principal = [Security.Principal.WindowsPrincipal]::new([Security.Principal.WindowsIdentity]::GetCurrent())) -and
                         $Principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
                     )


### PR DESCRIPTION
- Update the cmdlet `Initialize-TestEnvironment` to allow setting up
  the environment when run in PowerShell 5.0.
- Update the pipeline so the module will be tested on PowerShell 5.0 
  (Microsoft-hosted agent running Windows Server 2012 R2).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/dscresource.test/61)
<!-- Reviewable:end -->
