### PR TITLE
Added test for Unreleased section in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added a test to check for the correct formatting of the Unreleased section
+  in the Changelog
+
 ## [0.12.1] - 2020-01-16
 
 ### Fixed
 
 - Update the cmdlet `Initialize-TestEnvironment` to allow setting up
   the environment when run in PowerShell 5.0.
-- Update the pipeline so the module will be tested on PowerShell 5.0 
+- Update the pipeline so the module will be tested on PowerShell 5.0
   (Microsoft-hosted agent running Windows Server 2012 R2).
 
 ## [0.12.0] - 2020-01-16

--- a/source/Tests/QA/Changelog.common.Tests.ps1
+++ b/source/Tests/QA/Changelog.common.Tests.ps1
@@ -56,6 +56,10 @@ try
         It 'Changelog format compliant with keepachangelog format' -Skip:$skipTest {
             { Get-ChangelogData -Path (Join-Path -Path $ProjectPath -ChildPath 'CHANGELOG.md') -ErrorAction 'Stop' } | Should -Not -Throw
         }
+
+        It 'Changelog should have an Unreleased header' -Skip:$skipTest {
+            (Get-ChangelogData -Path (Join-Path -Path $ProjectPath -ChildPath 'CHANGELOG.md') -ErrorAction 'Stop').Unreleased.RawData | Should -Not -BeNullOrEmpty
+        }
     }
 }
 finally

--- a/tests/QA/module.tests.ps1
+++ b/tests/QA/module.tests.ps1
@@ -33,6 +33,10 @@ $allModuleFunctions = &$mut {Get-Command -Module $args[0] -CommandType Function 
         It 'Changelog format compliant with keepachangelog format' -skip:(![bool](Get-Command git -EA SilentlyContinue)) {
             { Get-ChangelogData (Join-Path $ProjectPath 'CHANGELOG.md') -ErrorAction Stop } | Should -Not -Throw
         }
+
+        It 'Changelog should have an Unreleased header' -Skip:$skipTest {
+            (Get-ChangelogData -Path (Join-Path -Path $ProjectPath -ChildPath 'CHANGELOG.md') -ErrorAction 'Stop').Unreleased.RawData | Should -Not -BeNullOrEmpty
+        }
     }
 
     Describe 'General module control' -Tags 'FunctionalQuality' {


### PR DESCRIPTION
This PR adds a test for the correct formatting of the "Unreleased" section in the changelog. This to prevent errors during publication of the module.

For example:
When the brackets around "Unreleased"are omitted, this test will throw a failure.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/dscresource.test/64)
<!-- Reviewable:end -->
