### PR TITLE
Update CI Agents - Fixes #68

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added a test to check for the correct formatting of the Unreleased section
-  in the Changelog
+  in the Changelog.
+
+### Changed
+
+- Updated the Azure DevOps Pipeline build agents to the supported versions
+  because the older `win1803` and `vs2015-win2012r2` versions have been
+  deprecated ([issue #68](https://github.com/dsccommunity/DscResource.Test/issues/68)).
 
 ## [0.12.1] - 2020-01-16
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -81,7 +81,7 @@ stages:
 
       - job: test_windows_core
         pool:
-          vmImage: 'win1803'
+          vmImage: 'windows-2019'
         steps:
           - task: DownloadBuildArtifacts@0
             inputs:
@@ -119,7 +119,7 @@ stages:
 
       - job: test_windows_ps
         pool:
-          vmImage: 'win1803'
+          vmImage: 'windows-2019'
         steps:
           - task: DownloadBuildArtifacts@0
             inputs:
@@ -157,7 +157,7 @@ stages:
 
       - job: test_windows_ps_5
         pool:
-          vmImage: 'vs2015-win2012r2'
+          vmImage: 'vs2017-win2016'
         steps:
           - task: DownloadBuildArtifacts@0
             inputs:


### PR DESCRIPTION
This PR updates the Azure DevOps Pipeline build agents to use the currently supported/available ones.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/dscresource.test/69)
<!-- Reviewable:end -->
