### PR TITLE
Fix: Cannot process argument transformation on parameter 'Root'. Cannot convert value to type System.String.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed #71. Updated `Invoke-DscResourceTest` to handle multiple PSModuleInfo objects
+
 ## [0.13.0] - 2020-03-28
 
 ### Added

--- a/source/Public/Invoke-DscResourceTest.ps1
+++ b/source/Public/Invoke-DscResourceTest.ps1
@@ -175,8 +175,9 @@ function Invoke-DscResourceTest
                 )
 
                 $ModulePsd1 = Join-Path -Path $OutputPath (Get-ChildItem @GetOutputModuleParams | Select-Object -First 1)
+                $dataFileImport = Import-PowerShellDataFile -Path $ModulePsd1
                 Write-Verbose "Loading $ModulePsd1"
-                $ModuleUnderTest = Import-Module -Name $ModulePsd1 -ErrorAction Stop -PassThru
+                $ModuleUnderTest = Import-Module -Name $ModulePsd1 -ErrorAction Stop -PassThru | Where-Object -FilterScript {$PSItem.Guid -eq $dataFileImport['GUID']}
             }
         }
 

--- a/source/Public/Invoke-DscResourceTest.ps1
+++ b/source/Public/Invoke-DscResourceTest.ps1
@@ -175,6 +175,7 @@ function Invoke-DscResourceTest
                 )
 
                 $ModulePsd1 = Join-Path -Path $OutputPath (Get-ChildItem @GetOutputModuleParams | Select-Object -First 1)
+                # Importing the module psd1 ensures the filtered Import-Module passthru returns only one PSModuleInfo Object: Issue #71
                 $dataFileImport = Import-PowerShellDataFile -Path $ModulePsd1
                 Write-Verbose "Loading $ModulePsd1"
                 $ModuleUnderTest = Import-Module -Name $ModulePsd1 -ErrorAction Stop -PassThru | Where-Object -FilterScript {$PSItem.Guid -eq $dataFileImport['GUID']}

--- a/tests/Unit/Public/Invoke-DscResourceTest.Tests.ps1
+++ b/tests/Unit/Public/Invoke-DscResourceTest.Tests.ps1
@@ -126,15 +126,25 @@ InModuleScope $ProjectName {
     }
 
     Describe 'Loading Opt Ins and Opt Outs by Tags' {
-        mock Import-Module -MockWith {
+        Mock Import-Module -MockWith {
             return @{
                 ModuleBase = 'TestDrive:\'
                 ModuleName = 'MyModule'
                 Path       = 'TestDrive:\MyModule.psd1'
+                Guid       = 'fd8c76f8-c702-49d0-9da8-f5661c2373bc'
             }
         }
+
         Mock Get-ChildItem -MockWith { @{FullName = 'C:\dummy.psd1' }}
 
+        Mock Import-PowerShellDataFile -MockWith {
+            return @{
+                ModuleBase = 'TestDrive:\'
+                ModuleName = 'MyModule'
+                Path       = 'TestDrive:\MyModule.psd1'
+                Guid       = 'fd8c76f8-c702-49d0-9da8-f5661c2373bc'
+            }
+        }
 
         Mock Get-StructuredObjectFromFile -ParameterFilter { $Path -like '*out.json' } -MockWith {
             param


### PR DESCRIPTION
Addresses Issue #71 "Cannot process argument transformation on parameter 'Root'. Cannot convert value to type System.String."

This bug will manifest itself when the module to be tested has a "ScriptsToProcess" key defined in the module manifest file.  The issue occurs due to Import-Module returning an array containing two or more PSModuleInfo objects.  One containing the actual module as well as one or more describing the script(s) defined in the ScriptsToProcess key in the manifest file.

The code producing the error contained in DscResource.Test\0.13.0\DscResource.Test.psm1:
```PowerShell
$ModuleUnderTest = Import-Module -Name $ModulePsd1 -ErrorAction Stop -PassThru
```
as well the following in DscResource.Test\0.13.0\Tests\QA\FileFormatting.common.Tests.ps1:
```PowerShell
$textFiles = @(Get-TextFilesList -Root $ModuleBase | WhereModuleFileNotExcluded)
```
Error:
![image](https://user-images.githubusercontent.com/12042836/81983114-da02bb80-9600-11ea-862a-b823412adf95.png)

I'm will be submitting a PR that will filter the actual module based on the manifest's defined GUID for the module under test.

- Fixes #71

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/dscresource.test/72)
<!-- Reviewable:end -->
