### PR TITLE
Fix Describing Changelog Management Module Tests - Fixes #81

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed error in `Tests/QA/Changelog.common.Tests.ps1` when Describing Changelog
   Management ([issue #81](https://github.com/dsccommunity/DscResource.Test/issues/81)).
 
+### Added
+
+- Added support for passing alternate trunk branch name through to
+  `Invoke-DscResourceTest.Tests.ps1` function ([issue #82](https://github.com/dsccommunity/DscResource.Test/issues/82)).
+
 ## [0.13.3] - 2020-06-01
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed error in `Tests/QA/Changelog.common.Tests.ps1` when Describing Changelog
+  Management ([issue #81](https://github.com/dsccommunity/DscResource.Test/issues/81)).
+
 ## [0.13.3] - 2020-06-01
 
 ### Fixed

--- a/source/Public/Invoke-DscResourceTest.ps1
+++ b/source/Public/Invoke-DscResourceTest.ps1
@@ -98,7 +98,11 @@ function Invoke-DscResourceTest
 
         [Parameter()]
         [System.Collections.Hashtable]
-        $Settings
+        $Settings,
+
+        [Parameter()]
+        [System.String]
+        $MainGitBranch = 'master'
     )
 
     begin
@@ -370,6 +374,7 @@ function Invoke-DscResourceTest
                     $item['Parameters']['ExcludeTag'] = $PSBoundParameters['ExcludeTagFilter']
                     $item['Parameters']['ExcludeModuleFile'] = $ExcludeModuleFile
                     $item['Parameters']['ExcludeSourceFile'] = $ExcludeSourceFile
+                    $item['Parameters']['MainGitBranch'] = $MainGitBranch
                 }
                 else
                 {
@@ -385,7 +390,8 @@ function Invoke-DscResourceTest
                             Tag                = $PSBoundParameters['TagFilter']
                             ExcludeTag         = $PSBoundParameters['ExcludeTagFilter']
                             ExcludeModuleFile  = $ExcludeModuleFile
-                            ExcludeSourceFile = $ExcludeSourceFile
+                            ExcludeSourceFile  = $ExcludeSourceFile
+                            MainGitBranch      = $MainGitBranch
                         }
                     }
                 }

--- a/source/Tests/QA/Changelog.common.Tests.ps1
+++ b/source/Tests/QA/Changelog.common.Tests.ps1
@@ -40,7 +40,7 @@ try
             # Get the list of changed files compared with main
             $headCommit = & git rev-parse HEAD
             $mainCommit = & git @('rev-parse', "origin/$MainGitBranch")
-            $filesChanged = & git @('diff', "$mainCommit...$headCommit",'--name-only')
+            $filesChanged = & git @('diff', "$mainCommit...$headCommit", '--name-only')
 
             if ($headCommit -ne $mainCommit)
             {

--- a/source/Tests/QA/Changelog.common.Tests.ps1
+++ b/source/Tests/QA/Changelog.common.Tests.ps1
@@ -11,7 +11,7 @@ param
     $ExcludeTag,
     $ExcludeModuleFile,
     $ExcludeSourceFile,
-    $MainGitBranch = 'master'
+    $MainGitBranch
 )
 
 if (-not $ProjectPath)

--- a/source/Tests/QA/Changelog.common.Tests.ps1
+++ b/source/Tests/QA/Changelog.common.Tests.ps1
@@ -10,7 +10,8 @@ param
     $Tag,
     $ExcludeTag,
     $ExcludeModuleFile,
-    $ExcludeSourceFile
+    $ExcludeSourceFile,
+    $MainGitBranch = 'master'
 )
 
 if (-not $ProjectPath)
@@ -36,14 +37,14 @@ try
             )
 
         It 'Changelog has been updated' -Skip:$skipTest {
-            # Get the list of changed files compared with master
+            # Get the list of changed files compared with main
             $headCommit = & git rev-parse HEAD
-            $masterCommit = & git rev-parse origin/master
-            $filesChanged = & git diff $masterCommit...$headCommit --name-only
+            $mainCommit = & git @('rev-parse', "origin/$MainGitBranch")
+            $filesChanged = & git @('diff', "$mainCommit...$headCommit",'--name-only')
 
-            if ($headCommit -ne $masterCommit)
+            if ($headCommit -ne $mainCommit)
             {
-                 # if we're not testing same commit (i.e. master..master)
+                 # if we're not testing same commit (i.e. main..main)
                 $filesChanged.Where{
                     (Split-Path -Path $_ -Leaf) -match '^changelog.md'
                 } | Should -Not -BeNullOrEmpty -Because 'the changelog should have at least one entry for every pull request'

--- a/source/Tests/QA/ExampleFiles.common.Tests.ps1
+++ b/source/Tests/QA/ExampleFiles.common.Tests.ps1
@@ -9,7 +9,8 @@ param (
     $Tag,
     $ExcludeTag,
     $ExcludeModuleFile,
-    $ExcludeSourceFile
+    $ExcludeSourceFile,
+    $MainGitBranch
 )
 
 Describe 'Common Tests - Validate Example Files' -Tag 'Common Tests - Validate Example Files' {

--- a/source/Tests/QA/ExampleFiles.common.Tests.ps1
+++ b/source/Tests/QA/ExampleFiles.common.Tests.ps1
@@ -10,7 +10,9 @@ param (
     $ExcludeTag,
     $ExcludeModuleFile,
     $ExcludeSourceFile,
-    $MainGitBranch
+
+    [Parameter(ValueFromRemainingArguments = $true)]
+    $Args
 )
 
 Describe 'Common Tests - Validate Example Files' -Tag 'Common Tests - Validate Example Files' {

--- a/source/Tests/QA/FileFormatting.common.Tests.ps1
+++ b/source/Tests/QA/FileFormatting.common.Tests.ps1
@@ -10,7 +10,8 @@ param
     $Tag,
     $ExcludeTag,
     $ExcludeModuleFile,
-    $ExcludeSourceFile
+    $ExcludeSourceFile,
+    $MainGitBranch
 )
 
 Describe 'Common Tests - File Formatting' -Tag 'Common Tests - File Formatting'  {

--- a/source/Tests/QA/FileFormatting.common.Tests.ps1
+++ b/source/Tests/QA/FileFormatting.common.Tests.ps1
@@ -11,7 +11,9 @@ param
     $ExcludeTag,
     $ExcludeModuleFile,
     $ExcludeSourceFile,
-    $MainGitBranch
+
+    [Parameter(ValueFromRemainingArguments = $true)]
+    $Args
 )
 
 Describe 'Common Tests - File Formatting' -Tag 'Common Tests - File Formatting'  {

--- a/source/Tests/QA/Localization.common.Tests.ps1
+++ b/source/Tests/QA/Localization.common.Tests.ps1
@@ -11,7 +11,9 @@ param
     $ExcludeTag,
     $ExcludeModuleFile,
     $ExcludeSourceFile,
-    $MainGitBranch
+
+    [Parameter(ValueFromRemainingArguments = $true)]
+    $Args
 )
 
 Describe 'Common Tests - Validate Localization' -Tag 'Common Tests - Validate Localization' {

--- a/source/Tests/QA/Localization.common.Tests.ps1
+++ b/source/Tests/QA/Localization.common.Tests.ps1
@@ -10,7 +10,8 @@ param
     $Tag,
     $ExcludeTag,
     $ExcludeModuleFile,
-    $ExcludeSourceFile
+    $ExcludeSourceFile,
+    $MainGitBranch
 )
 
 Describe 'Common Tests - Validate Localization' -Tag 'Common Tests - Validate Localization' {

--- a/source/Tests/QA/MarkdownLinks.common.Tests.ps1
+++ b/source/Tests/QA/MarkdownLinks.common.Tests.ps1
@@ -9,7 +9,8 @@ param (
     $Tag,
     $ExcludeTag,
     $ExcludeModuleFile,
-    $ExcludeSourceFile
+    $ExcludeSourceFile,
+    $MainGitBranch
 )
 
 if (!(Get-Module -Name 'MarkdownLinkCheck' -ListAvailable))

--- a/source/Tests/QA/ModuleFiles.common.Tests.ps1
+++ b/source/Tests/QA/ModuleFiles.common.Tests.ps1
@@ -10,7 +10,8 @@ param
     $Tag,
     $ExcludeTag,
     $ExcludeModuleFile,
-    $ExcludeSourceFile
+    $ExcludeSourceFile,
+    $MainGitBranch
 )
 
 Describe 'Common Tests - Validate Module Files' -Tag @('Module','Common Tests - Validate Module Files') {

--- a/source/Tests/QA/ModuleFiles.common.Tests.ps1
+++ b/source/Tests/QA/ModuleFiles.common.Tests.ps1
@@ -11,7 +11,9 @@ param
     $ExcludeTag,
     $ExcludeModuleFile,
     $ExcludeSourceFile,
-    $MainGitBranch
+
+    [Parameter(ValueFromRemainingArguments = $true)]
+    $Args
 )
 
 Describe 'Common Tests - Validate Module Files' -Tag @('Module','Common Tests - Validate Module Files') {

--- a/source/Tests/QA/ModuleManifest.common.Tests.ps1
+++ b/source/Tests/QA/ModuleManifest.common.Tests.ps1
@@ -11,7 +11,9 @@ param
     $ExcludeTag,
     $ExcludeModuleFile,
     $ExcludeSourceFile,
-    $MainGitBranch
+
+    [Parameter(ValueFromRemainingArguments = $true)]
+    $Args
 )
 
 Describe 'Common Tests - Module Manifest' -Tag 'Common Tests - Module Manifest' {

--- a/source/Tests/QA/ModuleManifest.common.Tests.ps1
+++ b/source/Tests/QA/ModuleManifest.common.Tests.ps1
@@ -10,7 +10,8 @@ param
     $Tag,
     $ExcludeTag,
     $ExcludeModuleFile,
-    $ExcludeSourceFile
+    $ExcludeSourceFile,
+    $MainGitBranch
 )
 
 Describe 'Common Tests - Module Manifest' -Tag 'Common Tests - Module Manifest' {

--- a/source/Tests/QA/PSSAResource.common.Tests.ps1
+++ b/source/Tests/QA/PSSAResource.common.Tests.ps1
@@ -10,7 +10,8 @@ param
     $Tag,
     $ExcludeTag,
     $ExcludeModuleFile,
-    $ExcludeSourceFile
+    $ExcludeSourceFile,
+    $MainGitBranch
 )
 
 Describe 'Common Tests - PS Script Analyzer on Resource Files' -Tag @('DscPSSA','Common Tests - PS Script Analyzer on Resource Files') {

--- a/source/Tests/QA/PSSAResource.common.Tests.ps1
+++ b/source/Tests/QA/PSSAResource.common.Tests.ps1
@@ -11,7 +11,9 @@ param
     $ExcludeTag,
     $ExcludeModuleFile,
     $ExcludeSourceFile,
-    $MainGitBranch
+
+    [Parameter(ValueFromRemainingArguments = $true)]
+    $Args
 )
 
 Describe 'Common Tests - PS Script Analyzer on Resource Files' -Tag @('DscPSSA','Common Tests - PS Script Analyzer on Resource Files') {

--- a/source/Tests/QA/Psm1Parsing.common.Tests.ps1
+++ b/source/Tests/QA/Psm1Parsing.common.Tests.ps1
@@ -11,7 +11,9 @@ param
     $ExcludeTag,
     $ExcludeModuleFile,
     $ExcludeSourceFile,
-    $MainGitBranch
+
+    [Parameter(ValueFromRemainingArguments = $true)]
+    $Args
 )
 
 Describe 'Common Tests - .psm1 File Parsing' -Tag 'Common Tests - .psm1 File Parsing' {

--- a/source/Tests/QA/Psm1Parsing.common.Tests.ps1
+++ b/source/Tests/QA/Psm1Parsing.common.Tests.ps1
@@ -10,7 +10,8 @@ param
     $Tag,
     $ExcludeTag,
     $ExcludeModuleFile,
-    $ExcludeSourceFile
+    $ExcludeSourceFile,
+    $MainGitBranch
 )
 
 Describe 'Common Tests - .psm1 File Parsing' -Tag 'Common Tests - .psm1 File Parsing' {

--- a/source/Tests/QA/PublishExampleFiles.Tests.ps1
+++ b/source/Tests/QA/PublishExampleFiles.Tests.ps1
@@ -12,7 +12,9 @@ param
     $ExcludeTag,
     $ExcludeModuleFile,
     $ExcludeSourceFile,
-    $MainGitBranch
+
+    [Parameter(ValueFromRemainingArguments = $true)]
+    $Args
 )
 
 Describe 'Common Tests - Validate Example Files To Be Published' -Tag 'Common Tests - Validate Example Files To Be Published' {

--- a/source/Tests/QA/PublishExampleFiles.Tests.ps1
+++ b/source/Tests/QA/PublishExampleFiles.Tests.ps1
@@ -11,7 +11,8 @@ param
     $Tag,
     $ExcludeTag,
     $ExcludeModuleFile,
-    $ExcludeSourceFile
+    $ExcludeSourceFile,
+    $MainGitBranch
 )
 
 Describe 'Common Tests - Validate Example Files To Be Published' -Tag 'Common Tests - Validate Example Files To Be Published' {

--- a/source/Tests/QA/RelativePathLength.common.Tests.ps1
+++ b/source/Tests/QA/RelativePathLength.common.Tests.ps1
@@ -10,7 +10,8 @@ param
     $Tag,
     $ExcludeTag,
     $ExcludeModuleFile,
-    $ExcludeSourceFile
+    $ExcludeSourceFile,
+    $MainGitBranch
 )
 
 Describe 'Common Tests - Relative Path Length' -Tag 'Common Tests - Relative Path Length' {

--- a/source/Tests/QA/RelativePathLength.common.Tests.ps1
+++ b/source/Tests/QA/RelativePathLength.common.Tests.ps1
@@ -11,7 +11,9 @@ param
     $ExcludeTag,
     $ExcludeModuleFile,
     $ExcludeSourceFile,
-    $MainGitBranch
+
+    [Parameter(ValueFromRemainingArguments = $true)]
+    $Args
 )
 
 Describe 'Common Tests - Relative Path Length' -Tag 'Common Tests - Relative Path Length' {

--- a/source/Tests/QA/ResourceSchema.common.Tests.ps1
+++ b/source/Tests/QA/ResourceSchema.common.Tests.ps1
@@ -5,7 +5,13 @@ param
     $ModuleBase,
     $ModuleManifest,
     $ProjectPath,
-    $SourceManifest
+    $SourcePath,
+    $SourceManifest,
+    $Tag,
+    $ExcludeTag,
+    $ExcludeModuleFile,
+    $ExcludeSourceFile,
+    $MainGitBranch
 )
 
 Describe 'Common Tests - Script Resource Schema Validation' -Tag 'WindowsOnly' {

--- a/source/Tests/QA/ScriptFiles.common.Tests.ps1
+++ b/source/Tests/QA/ScriptFiles.common.Tests.ps1
@@ -10,7 +10,8 @@ param
     $Tag,
     $ExcludeTag,
     $ExcludeModuleFile,
-    $ExcludeSourceFile
+    $ExcludeSourceFile,
+    $MainGitBranch
 )
 
 Describe 'Common Tests - Validate Script Files' -Tag 'Script','Common Tests - Validate Script Files' {

--- a/source/Tests/QA/ScriptFiles.common.Tests.ps1
+++ b/source/Tests/QA/ScriptFiles.common.Tests.ps1
@@ -11,7 +11,9 @@ param
     $ExcludeTag,
     $ExcludeModuleFile,
     $ExcludeSourceFile,
-    $MainGitBranch
+
+    [Parameter(ValueFromRemainingArguments = $true)]
+    $Args
 )
 
 Describe 'Common Tests - Validate Script Files' -Tag 'Script','Common Tests - Validate Script Files' {

--- a/tests/QA/module.tests.ps1
+++ b/tests/QA/module.tests.ps1
@@ -23,7 +23,7 @@ $allModuleFunctions = &$mut {Get-Command -Module $args[0] -CommandType Function 
             # Get the list of changed files compared with master
             $HeadCommit = &git rev-parse HEAD
             $MasterCommit = &git rev-parse origin/master
-            $filesChanged = &git diff $MasterCommit...$HeadCommit --name-only
+            $filesChanged = &git @('diff', "$MasterCommit...$HeadCommit", '--name-only')
 
             if($HeadCommit -ne $MasterCommit) { # if we're not testing same commit (i.e. master..master)
                 $filesChanged.Where{ (Split-Path $_ -Leaf) -match '^changelog' } | Should -Not -BeNullOrEmpty

--- a/tests/Unit/Public/Invoke-DscResourceTest.Tests.ps1
+++ b/tests/Unit/Public/Invoke-DscResourceTest.Tests.ps1
@@ -93,13 +93,13 @@ InModuleScope $ProjectName {
 
             It 'works when using an existing module' {
                 {
-                    Invoke-DscResourceTest -Module Microsoft.PowerShell.Utility -Script '.' -Tag nothing
+                    Invoke-DscResourceTest -Module Microsoft.PowerShell.Utility -Script '.' -Tag nothing -Verbose
                 } | Should -Not -Throw
                 Assert-MockCalled -CommandName Get-Command -Scope It
             }
 
             It 'Should call Invoke-Pester with correct parameters' {
-                $result = Invoke-DscResourceTest -Module Microsoft.PowerShell.Utility -Script '.' -Tag nothing
+                $result = Invoke-DscResourceTest -Module Microsoft.PowerShell.Utility -Script '.' -Tag nothing -Verbose
                 $result.Script.Path | Should -BeExactly '.'
                 $result.Script.Parameters.ModuleName | Should -BeExactly 'Microsoft.PowerShell.Utility'
                 $result.Script.Parameters.keys | Should -HaveCount 11
@@ -110,7 +110,7 @@ InModuleScope $ProjectName {
 
         Context 'When with alternate MainGitBranch' {
             It 'Should call Invoke-Pester with correct parameters' {
-                $result = Invoke-DscResourceTest -Module Microsoft.PowerShell.Utility -Script '.' -Tag nothing -MainGitBranch 'main'
+                $result = Invoke-DscResourceTest -Module Microsoft.PowerShell.Utility -Script '.' -Tag nothing -MainGitBranch 'main' -Verbose
                 $result.Script.Path | Should -BeExactly '.'
                 $result.Script.Parameters.ModuleName | Should -BeExactly 'Microsoft.PowerShell.Utility'
                 $result.Script.Parameters.keys | Should -HaveCount 11
@@ -164,7 +164,7 @@ InModuleScope $ProjectName {
                 ModuleName    = 'Microsoft.PowerShell.Utility'
                 ModuleVersion = '1.0.0.0'
             }
-            $result = Invoke-DscResourceTest -FullyQualifiedModule $FQM -Script .
+            $result = Invoke-DscResourceTest -FullyQualifiedModule $FQM -Script . -Verbose
             $result.Script.Path | Should -BeExactly '.'
             $result.Script.Parameters.ModuleName | Should -BeExactly 'Microsoft.PowerShell.Utility'
             $result.Script.Parameters.keys | Should -HaveCount 11
@@ -216,7 +216,7 @@ InModuleScope $ProjectName {
         }
 
         It 'Should override properly the Script parameters for Invoke-Pester' {
-            $result = Invoke-DscResourceTest -ProjectPath $PSScriptRoot\..\assets
+            $result = Invoke-DscResourceTest -ProjectPath $PSScriptRoot\..\assets -Verbose
             Assert-MockCalled Get-Command -Scope Describe
             $result.Script.Parameters.ModuleName | Should -Not -BeExactly 'dummy'
             $result.script.Parameters.Keys | Should -HaveCount 11
@@ -246,10 +246,9 @@ InModuleScope $ProjectName {
                 Parameters = @{
                     'ModuleName' = 'dummy'
                 }
-            } -Module 'Microsoft.PowerShell.Utility'
+            } -Module 'Microsoft.PowerShell.Utility'  -Verbose
             $result.Script.Parameters.ModuleName | Should -Not -BeExactly 'dummy'
             $result.script.Parameters.Keys | Should -HaveCount 11
-
         }
     }
 }

--- a/tests/Unit/Public/Invoke-DscResourceTest.Tests.ps1
+++ b/tests/Unit/Public/Invoke-DscResourceTest.Tests.ps1
@@ -1,132 +1,186 @@
 $ProjectPath = "$PSScriptRoot\..\..\.." | Convert-Path
 $ProjectName = ((Get-ChildItem -Path $ProjectPath\*\*.psd1).Where{
         ($_.Directory.Name -match 'source|src' -or $_.Directory.Name -eq $_.BaseName) -and
-        $(try { Test-ModuleManifest $_.FullName -ErrorAction Stop } catch { $false } )
+        $(try
+            {
+                Test-ModuleManifest $_.FullName -ErrorAction Stop
+            }
+            catch
+            {
+                $false
+            } )
     }).BaseName
 
 Import-Module $ProjectName
 
 InModuleScope $ProjectName {
     $ProjectPath = "$PSScriptRoot\..\..\.." | Convert-Path
-    mock Get-Command -MockWith {
+    Mock -CommandName Get-Command -MockWith {
         {
-            param(
-                 $Module
-                ,$FullyQualifiedModule
-                ,$ProjectPath
-                ,$Script
-                ,$TestName
-                ,$EnableExit
-                ,$Tag
-                ,$ExcludeTag
-                ,$PassThru
-                ,$CodeCoverage
-                ,$CodeCoverageOutputFile
-                ,$CodeCoverageOutputFileFormat
-                ,$Strict
-                ,$OutputFile
-                ,$OutputFormat
-                ,$Quiet
-                ,$PesterOption
-                ,$Show
-                ,$Settings
-                ,$Verbose
-                ,$Debug
-                ,$ErrorAction
-                ,$WarningAction
-                ,$InformationAction
-                ,$ErrorVariable
-                ,$WarningVariable
-                ,$InformationVariable
-                ,$OutVariable
-                ,$OutBuffer
-                ,$PipelineVariable
+            [CmdletBinding()]
+            param (
+                [Parameter()]
+                $Module,
+
+                [Parameter()]
+                $FullyQualifiedModule,
+
+                [Parameter()]
+                $ProjectPath,
+
+                [Parameter()]
+                $Script,
+
+                [Parameter()]
+                $TestName,
+
+                [Parameter()]
+                $EnableExit,
+
+                [Parameter()]
+                $Tag,
+
+                [Parameter()]
+                $ExcludeTag,
+
+                [Parameter()]
+                $PassThru,
+
+                [Parameter()]
+                $CodeCoverage,
+
+                [Parameter()]
+                $CodeCoverageOutputFile,
+
+                [Parameter()]
+                $CodeCoverageOutputFileFormat,
+
+                [Parameter()]
+                $Strict,
+
+                [Parameter()]
+                $OutputFile,
+
+                [Parameter()]
+                $OutputFormat,
+
+                [Parameter()]
+                $Quiet,
+
+                [Parameter()]
+                $PesterOption,
+
+                [Parameter()]
+                $Show,
+
+                [Parameter()]
+                $Settings,
+
+                [Parameter()]
+                $MainGitBranch
             )
+
             return $PSBoundParameters
         }
     }
-    mock Get-StructuredObjectFromFile -MockWith { @('noTag') }
+    Mock -CommandName Get-StructuredObjectFromFile -MockWith { @('noTag') }
 
     Describe 'Invoke-DscResourceTest Resolving Built Module' {
-
-        Context 'Calling By Module name' {
-
-            It 'fails when using a missing module' {
-                {Invoke-DscResourceTest -Module ModuleThatDontExist } | Should -Throw
+        Context 'When calling by module name' {
+            It 'Should fail when using a missing module' {
+                { Invoke-DscResourceTest -Module ModuleThatDontExist } | Should -Throw
             }
 
             It 'works when using an existing module' {
-                { Invoke-DscResourceTest -Module Microsoft.PowerShell.Utility -Script "." -Tag nothing } | Should -Not -Throw
+                {
+                    Invoke-DscResourceTest -Module Microsoft.PowerShell.Utility -Script '.' -Tag nothing
+                } | Should -Not -Throw
                 Assert-MockCalled -CommandName Get-Command -Scope It
             }
 
-            It 'Calls Invoke-Pester with correct parameters' {
-                $result = Invoke-DscResourceTest -Module Microsoft.PowerShell.Utility -Script "." -Tag nothing
+            It 'Should call Invoke-Pester with correct parameters' {
+                $result = Invoke-DscResourceTest -Module Microsoft.PowerShell.Utility -Script '.' -Tag nothing
                 $result.Script.Path | Should -BeExactly '.'
                 $result.Script.Parameters.ModuleName | Should -BeExactly 'Microsoft.PowerShell.Utility'
-                $result.Script.Parameters.keys | Should -HaveCount 10
+                $result.Script.Parameters.keys | Should -HaveCount 11
                 $result.Tag | Should -BeExactly 'nothing' `
-                                -Because 'When parameter is specified it override defaults & settings'
+                    -Because 'When parameter is specified it override defaults & settings'
             }
         }
 
-        Context 'Calling by Module Path' {
+        Context 'When with alternate MainGitBranch' {
+            It 'Should call Invoke-Pester with correct parameters' {
+                $result = Invoke-DscResourceTest -Module Microsoft.PowerShell.Utility -Script '.' -Tag nothing -MainGitBranch 'main'
+                $result.Script.Path | Should -BeExactly '.'
+                $result.Script.Parameters.ModuleName | Should -BeExactly 'Microsoft.PowerShell.Utility'
+                $result.Script.Parameters.keys | Should -HaveCount 11
+                $result.Script.Parameters.MainGitBranch | Should -BeExactly 'main' `
+                    -Because 'When parameter is specified it override defaults & settings'
+                $result.Tag | Should -BeExactly 'nothing' `
+                    -Because 'When parameter is specified it override defaults & settings'
+            }
+        }
 
-            It 'Fails when using a wrong path' {
-                {Invoke-DscResourceTest -Module "C:\MyModuleNameDoesNotExist"} | Should -Throw
+        Context 'When calling by module path' {
+            It 'Should fail when using a wrong path' {
+                {
+                    Invoke-DscResourceTest -Module 'C:\MyModuleNameDoesNotExist'
+                } | Should -Throw
             }
 
-            mock Import-Module -MockWith {
+            Mock -CommandName Import-Module -MockWith {
                 param (
+                    [Parameter()]
                     $Name,
-                    $FullyQualifiedModule
+
+                    [Parameter()]
+                    $FullyQualifiedModule,
+
+                    [Parameter()]
+                    $PassThru,
+
+                    [Parameter()]
+                    $Force
                 )
-                return ($PSBoundParameters + @{
-                    ModuleBase = 'TestDrive:\'
-                    ModuleName = 'MyModule'
-                    Path       = 'TestDrive:\MyModule.psd1'
-                })
+
+                return (
+                    $PSBoundParameters + @{
+                        ModuleBase = 'TestDrive:\'
+                        ModuleName = 'MyModule'
+                        Path       = 'TestDrive:\MyModule.psd1'
+                    }
+                )
             }
 
-            It 'Invokes Pester using correct parameters when using an existing Module Path' {
-                $result = Invoke-DscResourceTest -Module "C:\MyModuleNameDoesNotExist.psd1"
+            It 'Should invoke pester using correct parameters when using an existing module path' {
+                $result = Invoke-DscResourceTest -Module 'C:\MyModuleNameDoesNotExist.psd1' -Verbose
                 $result.Script.Parameters.ProjectPath | Should -BeNullOrEmpty
-                $result.Script.Parameters.ModuleName  | Should -BeExactly 'C:\MyModuleNameDoesNotExist.psd1'
+                $result.Script.Parameters.ModuleName | Should -BeExactly 'C:\MyModuleNameDoesNotExist.psd1'
             }
         }
 
-        Context 'Calling by Module Specification' {
-            [Microsoft.PowerShell.Commands.ModuleSpecification]$FQM = @{
-                ModuleName = 'Microsoft.PowerShell.Utility'
+        Context 'When calling by module specification' {
+            [Microsoft.PowerShell.Commands.ModuleSpecification] $FQM = @{
+                ModuleName    = 'Microsoft.PowerShell.Utility'
                 ModuleVersion = '1.0.0.0'
             }
             $result = Invoke-DscResourceTest -FullyQualifiedModule $FQM -Script .
             $result.Script.Path | Should -BeExactly '.'
-                $result.Script.Parameters.ModuleName | Should -BeExactly 'Microsoft.PowerShell.Utility'
-                $result.Script.Parameters.keys | Should -HaveCount 10
-
+            $result.Script.Parameters.ModuleName | Should -BeExactly 'Microsoft.PowerShell.Utility'
+            $result.Script.Parameters.keys | Should -HaveCount 11
         }
 
-        Context 'Calling by Project Path' {
+        Context 'When calling by project path' {
             $null = Invoke-DscResourceTest -ProjectPath $ProjectPath
-            # mock Import-Module -MockWith {
-            #     return @{
-            #         ModuleBase = 'TestDrive:\'
-            #         ModuleName = 'MyModule'
-            #         Path       = 'TestDrive:\MyModule.psd1'
-            #     }
-            # } -ParameterFilter {$Name -like '*.psd1'}
 
-
-            It 'Calls by Project path' {
+            It 'Should call by project path' {
                 Assert-MockCalled -CommandName Get-Command -Scope Context
-                # Assert-MockCalled -CommandName Import-Module -Scope Context
             }
         }
     }
 
     Describe 'Loading Opt Ins and Opt Outs by Tags' {
-        Mock Import-Module -MockWith {
+        Mock -CommandName Import-Module -MockWith {
             return @{
                 ModuleBase = 'TestDrive:\'
                 ModuleName = 'MyModule'
@@ -135,9 +189,13 @@ InModuleScope $ProjectName {
             }
         }
 
-        Mock Get-ChildItem -MockWith { @{FullName = 'C:\dummy.psd1' }}
+        Mock -CommandName Get-ChildItem -MockWith {
+            @{
+                FullName = 'C:\dummy.psd1'
+            }
+        }
 
-        Mock Import-PowerShellDataFile -MockWith {
+        Mock -CommandName Import-PowerShellDataFile -MockWith {
             return @{
                 ModuleBase = 'TestDrive:\'
                 ModuleName = 'MyModule'
@@ -146,43 +204,51 @@ InModuleScope $ProjectName {
             }
         }
 
-        Mock Get-StructuredObjectFromFile -ParameterFilter { $Path -like '*out.json' } -MockWith {
-            param
-            (
+        Mock -CommandName Get-StructuredObjectFromFile -ParameterFilter {
+            $Path -like '*out.json'
+        } -MockWith {
+            param (
+                [Parameter()]
                 $Path
             )
+
             @('noTag', 'ExcludeTag')
         }
 
-        It 'overrides properly the Script parameters for Invoke-Pester' {
+        It 'Should override properly the Script parameters for Invoke-Pester' {
             $result = Invoke-DscResourceTest -ProjectPath $PSScriptRoot\..\assets
             Assert-MockCalled Get-Command -Scope Describe
-            $result.Script.Parameters.ModuleName  | Should -Not -BeExactly 'dummy'
-            $result.script.Parameters.Keys | Should -HaveCount 10
+            $result.Script.Parameters.ModuleName | Should -Not -BeExactly 'dummy'
+            $result.script.Parameters.Keys | Should -HaveCount 11
             $result.Tag | Should -HaveCount 1
             $result.ExcludeTag | Should -HaveCount 1
         }
-
     }
 
     Describe 'Merging settings from Config and params' {
-
     }
 
     Describe 'Pester Scripts Parameters' {
-        mock Import-Module -MockWith {
+        Mock -CommandName Import-Module -MockWith {
             return @{
                 ModuleBase = 'TestDrive:\'
                 ModuleName = 'MyModule'
                 Path       = 'TestDrive:\MyModule.psd1'
 
             }
-        } -ParameterFilter {$Name -like '*.psd1'}
+        } -ParameterFilter {
+            $Name -like '*.psd1'
+        }
 
-        It 'overrides properly the Script parameters for Invoke-Pester' {
-            $result = Invoke-DscResourceTest -Script @{Path = '.'; Parameters = @{'ModuleName' = 'dummy'}} -Module 'Microsoft.PowerShell.Utility'
-            $result.Script.Parameters.ModuleName  | Should -Not -BeExactly 'dummy'
-            $result.script.Parameters.Keys | Should -HaveCount 10
+        It 'Should override properly the Script parameters for Invoke-Pester' {
+            $result = Invoke-DscResourceTest -Script @{
+                Path       = '.'
+                Parameters = @{
+                    'ModuleName' = 'dummy'
+                }
+            } -Module 'Microsoft.PowerShell.Utility'
+            $result.Script.Parameters.ModuleName | Should -Not -BeExactly 'dummy'
+            $result.script.Parameters.Keys | Should -HaveCount 11
 
         }
     }


### PR DESCRIPTION
- Fixed error in `Tests/QA/Changelog.common.Tests.ps1` when Describing Changelog
  Management ([issue #81](https://github.com/dsccommunity/DscResource.Test/issues/81)).
- Added support for passing alternate trunk branch name through to
  `Invoke-DscResourceTest.Tests.ps1` function ([issue #82](https://github.com/dsccommunity/DscResource.Test/issues/82)).

- Fixes #81 
- Fixes #82 

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/dscresource.test/83)
<!-- Reviewable:end -->
