### PR TITLE
Prevent deploy stage from running outside dsccommunity Org - Fixes #86

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Fix deploy condition in `azure-pipelines.yml` so that it does not execute
+  unless run from the `dsccommunity` Azure DevOps org ([issue #86](https://github.com/dsccommunity/DscResource.Test/issues/86)).
+
 ## [0.14.0] - 2020-08-08
 
 ### Fixed

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -262,14 +262,14 @@ stages:
 
   - stage: Deploy
     dependsOn: test_module
-    # Only execute deploy stage if we're on master and previous stage succeeded
     condition: |
       and(
         succeeded(),
         or(
           eq(variables['Build.SourceBranch'], 'refs/heads/master'),
           startsWith(variables['Build.SourceBranch'], 'refs/tags/')
-        )
+        ),
+        contains(variables['System.TeamFoundationCollectionUri'], 'dsccommunity')
       )
     jobs:
       - job: Deploy_Artefact


### PR DESCRIPTION
This PR updates the pipeline to prevent the deploy stage running unless the AzDO pipeline org is dsccommunity.