### PR TITLE
Add new common test helper functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Updated cmdlet documentation in README.md.
+
+### Added
+
+- Added test helper functions `Get-InvalidResultRecord` and `Get-InvalidOperationRecord`.
+- Added alias `Get-ObjectNotFoundRecord` that points to `Get-InvalidResultRecord`.
+
 ## [0.14.1] - 2020-11-12
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -59,3 +59,356 @@ PS C:\src\DscResource.Test> build.ps1 -ResolveDependency
 # this will first bootstrap the environment by downloading dependencies required
 # then run the '.' task workflow as defined in build.yml
 ```
+
+## Cmdlets
+<!-- markdownlint-disable MD036 - Emphasis used instead of a heading -->
+
+Refer to the comment-based help for more information about these helper
+functions.
+
+### `Clear-DscLcmConfiguration`
+
+Clear the DSC LCM by performing the following functions:
+
+1. Cancel any currently executing DSC LCM operations
+1. Remove any DSC configurations that:
+    - are currently applied
+    - are pending application
+    - have been previously applied
+
+The purpose of this function is to ensure the DSC LCM is in a known
+and idle state before an integration test is performed that will
+apply a configuration.
+
+This is to prevent an integration test from being performed but failing
+because the DSC LCM is applying a previous configuration.
+
+This function should be called after each Describe block in an integration
+test to ensure the DSC LCM is reset before another test DSC configuration
+is applied.
+
+#### Syntax
+
+<!-- markdownlint-disable MD013 - Line length -->
+```plaintext
+Clear-DscLcmConfiguration [<CommonParameters>]
+```
+<!-- markdownlint-enable MD013 - Line length -->
+
+#### Outputs
+
+None.
+
+#### Example
+
+```powershell
+Clear-DscLcmConfiguration
+```
+
+This command will Stop the DSC LCM and clear out any DSC configurations.
+
+### `Get-InvalidOperationRecord`
+
+Returns an invalid operation exception object.
+
+#### Syntax
+
+<!-- markdownlint-disable MD013 - Line length -->
+```plaintext
+Get-InvalidOperationRecord [-Message] <string> [[-ErrorRecord] <ErrorRecord>] [<CommonParameters>]
+```
+<!-- markdownlint-enable MD013 - Line length -->
+
+#### Outputs
+
+**System.Object**
+
+#### Example
+
+```powershell
+$mockErrorRecord = Get-InvalidOperationRecord -Message (
+    $script:localizedData.FailedToRename -f $name
+)
+```
+
+This will return an error record with the localized string as the exception
+message.
+
+```powershell
+try
+{
+    # Something that tries an operation.
+}
+catch
+{
+    $mockErrorRecord = Get-InvalidOperationRecord -ErrorRecord $_ -Message (
+        $script:localizedData.FailedToRename -f $name
+    )
+}
+```
+
+This will return an error record. The exception message will be concatenated
+to include both the localized string and all the inner exceptions messages
+from error record that was passed from the `catch`-block.
+
+### `Get-InvalidResultRecord`
+
+Returns an invalid result exception object.
+
+#### Syntax
+
+<!-- markdownlint-disable MD013 - Line length -->
+```plaintext
+Get-InvalidResultRecord [-Message] <string> [[-ErrorRecord] <ErrorRecord>] [<CommonParameters>]
+```
+<!-- markdownlint-enable MD013 - Line length -->
+
+#### Aliases
+
+`Get-ObjectNotFound`
+
+#### Outputs
+
+**System.Object**
+
+#### Example
+
+```powershell
+$mockErrorRecord = Get-InvalidResultRecord -Message (
+    $script:localizedData.FailedToGetAllFromName -f $name
+)
+```
+
+This will return an error record with the localized string as the exception
+message.
+
+```powershell
+try
+{
+    # Something that tries to return an expected result.
+}
+catch
+{
+    $mockErrorRecord = Get-InvalidResultRecord -ErrorRecord $_ -Message (
+        $script:localizedData.FailedToGetAllFromName -f $name
+    )
+}
+```
+
+This will return an error record. The exception message will be concatenated
+to include both the localized string and all the inner exceptions messages
+from error record that was passed from the `catch`-block.
+
+### `Initialize-TestEnvironment`
+
+Initializes an environment for running unit or integration tests
+on a DSC resource.
+
+This includes:
+
+1. Updates the $env:PSModulePath to ensure the correct module is tested.
+1. Imports the module to test.
+1. Sets the PowerShell ExecutionMode to Unrestricted.
+1. returns a test environment object to store the settings.
+
+The above changes are reverted by calling the Restore-TestEnvironment
+function with the returned object.
+
+Returns a test environment object which must be passed to the
+Restore-TestEnvironment function to allow it to restore the system
+back to the original state.
+
+#### Syntax
+
+<!-- markdownlint-disable MD013 - Line length -->
+```plaintext
+Initialize-TestEnvironment [-Module] <string> [-DscResourceName] <string> 
+  [-TestType] {Unit | Integration | All} [[-ResourceType] {Mof | Class}]
+  [[-ProcessExecutionPolicy] {AllSigned | Bypass | RemoteSigned | Unrestricted}] 
+  [[-MachineExecutionPolicy] {AllSigned | Bypass | RemoteSigned | Unrestricted}] 
+  [<CommonParameters>]
+```
+<!-- markdownlint-enable MD013 - Line length -->
+
+#### Outputs
+
+**System.Collections.Hashtable**
+
+#### Example
+
+```powershell
+$script:testEnvironment = Initialize-TestEnvironment `
+    -DSCModuleName 'NetworkingDsc' `
+    -DSCResourceName 'DSC_Firewall' `
+    -ResourceType 'Mof' `
+    -TestType 'Unit'
+```
+
+This command will initialize the test environment for Unit testing
+the DSC_Firewall MOF-based DSC resource in the NetworkingDsc DSC resource
+module.
+
+```powershell
+$script:testEnvironment = Initialize-TestEnvironment `
+    -DSCModuleName 'NetworkingDsc' `
+    -DSCResourceName 'DSC_Firewall' `
+    -ResourceType 'Class' `
+    -TestType 'Unit'
+```
+
+This command will initialize the test environment for Unit testing
+the DSC_Firewall Class-based DSC resource in the NetworkingDsc DSC resource'
+module.
+
+```powershell
+$script:testEnvironment = Initialize-TestEnvironment `
+    -DSCModuleName 'NetworkingDsc' `
+    -DSCResourceName 'DSC_Firewall' `
+    -ResourceType 'Class' `
+    -TestType 'Integration'
+```
+
+This command will initialize the test environment for Integration testing
+the DSC_Firewall DSC resource in the NetworkingDsc DSC resource module.
+
+### `Invoke-DscResourceTest`
+
+Wrapper for Invoke-Pester. It is used primarily by the pipeline and can
+be used to run test by providing a project path, module specification,
+by module name, or path.
+
+#### Syntax
+
+<!-- markdownlint-disable MD013 - Line length -->
+```plaintext
+Invoke-DscResourceTest [[-ProjectPath] <string>] [[-Path] <Object[]>] [[-TestName] <string[]>]
+  [[-EnableExit]] [[-TagFilter] <string[]>] [-ExcludeTagFilter <string[]>] [-ExcludeModuleFile <string[]>]
+  [-ExcludeSourceFile <string[]>] [-PassThru] [-CodeCoverage <Object[]>] [-CodeCoverageOutputFile <string>]
+  [-CodeCoverageOutputFileFormat {JaCoCo}] [-Strict] [-Output <string>] [-OutputFile <string>] 
+  [-OutputFormat {NUnitXml | JUnitXml}] [-Quiet] [-PesterOption <Object>]
+  [-Show {None | Default | Passed | Failed | Pending | Skipped | Inconclusive | Describe | Context | Summary | Header | Fails | All}]
+  [-Settings <hashtable>] [-MainGitBranch <string>] [<CommonParameters>]
+
+Invoke-DscResourceTest [[-Module] <string>] [[-Path] <Object[]>] [[-TestName] <string[]>] 
+  [[-EnableExit]] [[-TagFilter] <string[]>] [-ExcludeTagFilter <string[]>] [-ExcludeModuleFile <string[]>]
+  [-ExcludeSourceFile <string[]>] [-PassThru] [-CodeCoverage <Object[]>] [-CodeCoverageOutputFile <string>]
+  [-CodeCoverageOutputFileFormat {JaCoCo}] [-Strict] [-Output <string>] [-OutputFile <string>]
+  [-OutputFormat {NUnitXml | JUnitXml}] [-Quiet] [-PesterOption <Object>]
+  [-Show {None | Default | Passed | Failed | Pending | Skipped | Inconclusive | Describe | Context | Summary | Header | Fails | All}]
+  [-Settings <hashtable>] [-MainGitBranch <string>] [<CommonParameters>]
+
+Invoke-DscResourceTest [[-FullyQualifiedModule] <ModuleSpecification>] [[-Path] <Object[]>]
+  [[-TestName] <string[]>] [[-EnableExit]] [[-TagFilter] <string[]>] [-ExcludeTagFilter <string[]>]
+  [-ExcludeModuleFile <string[]>] [-ExcludeSourceFile <string[]>] [-PassThru] [-CodeCoverage <Object[]>]
+  [-CodeCoverageOutputFile <string>] [-CodeCoverageOutputFileFormat {JaCoCo}] [-Strict] [-Output <string>]
+  [-OutputFile <string>] [-OutputFormat {NUnitXml | JUnitXml}] [-Quiet] [-PesterOption <Object>]
+  [-Show {None | Default | Passed | Failed | Pending | Skipped | Inconclusive | Describe | Context | Summary | Header | Fails | All}]
+  [-Settings <hashtable>] [-MainGitBranch <string>] [<CommonParameters>]
+```
+<!-- markdownlint-enable MD013 - Line length -->
+
+#### Outputs
+
+**System.Object**
+
+#### Example
+
+None.
+
+### `New-DscSelfSignedCertificate`
+
+This command will create a new self-signed certificate to be used to
+compile configurations.
+
+#### Syntax
+
+<!-- markdownlint-disable MD013 - Line length -->
+```plaintext
+New-DscSelfSignedCertificate [<CommonParameters>]
+```
+<!-- markdownlint-enable MD013 - Line length -->
+
+#### Outputs
+
+Returns the created certificate. Writes the path to the public
+certificate in the machine environment variable $env:DscPublicCertificatePath,
+and the certificate thumbprint in the machine environment variable
+$env:DscCertificateThumbprint.
+
+#### Example
+
+```powershell
+$certificate = New-DscSelfSignedCertificate
+```
+
+This command will create and return a new self-signed certificate to be
+used to compile configurations. The command will write the path to the
+public certificate in the machine environment variable `$env:DscPublicCertificatePath`,
+and the certificate thumbprint in the machine environment variable
+`$env:DscCertificateThumbprint`.
+
+If a certificate with subject 'DscEncryptionCert' already exists, that
+certificate will be returned instead of creating a new. The command will
+assume that the existing certificate was created with the same command.
+
+### `Restore-TestEnvironment`
+
+Restores the environment after running unit or integration tests
+on a DSC resource.
+
+This restores the following changes made by calling
+Initialize-TestEnvironment:
+
+1. Restores the $env:PSModulePath if it was changed.
+1. Restores the PowerShell execution policy.
+1. Resets the DSC LCM if running Integration tests.
+
+#### Syntax
+
+<!-- markdownlint-disable MD013 - Line length -->
+```plaintext
+Restore-TestEnvironment [-TestEnvironment] <hashtable> [<CommonParameters>]
+```
+<!-- markdownlint-enable MD013 - Line length -->
+
+#### Outputs
+
+None.
+
+#### Example
+
+```powershell
+Restore-TestEnvironment -TestEnvironment $script:testEnvironment
+```
+
+This will restore the test environment and use the values that is provided
+in the hashtable passed to the command. The hasttable that is passed should
+have been created by `Initialize-TestEnvironment`.
+
+### `Wait-ForIdleLcm`
+
+Waits for LCM to become idle and optionally clears the LCM by running
+`Clear-DscLcmConfiguration`.
+
+It is meant to be used in integration test where integration tests run to
+quickly before LCM have time to cool down.
+
+#### Syntax
+
+<!-- markdownlint-disable MD013 - Line length -->
+```plaintext
+Wait-ForIdleLcm [-Clear] [<CommonParameters>]
+```
+<!-- markdownlint-enable MD013 - Line length -->
+
+#### Outputs
+
+None.
+
+#### Example
+
+```powershell
+Wait-ForIdleLcm -Clear
+```
+
+This will wait for the LCM to become idle and then clear the LCM.

--- a/source/Public/Clear-DscLcmConfiguration.ps1
+++ b/source/Public/Clear-DscLcmConfiguration.ps1
@@ -17,6 +17,7 @@
         This function should be called after each Describe block in an integration
         test to ensure the DSC LCM is reset before another test DSC configuration
         is applied.
+
     .EXAMPLE
         Clear-DscLcmConfiguration
 

--- a/source/Public/Get-InvalidOperationRecord.ps1
+++ b/source/Public/Get-InvalidOperationRecord.ps1
@@ -1,0 +1,58 @@
+<#
+    .SYNOPSIS
+        Returns an invalid operation exception object.
+
+    .PARAMETER Message
+        The message explaining why this error is being thrown.
+
+    .PARAMETER ErrorRecord
+        The error record containing the exception that is causing this terminating
+        error.
+#>
+function Get-InvalidOperationRecord
+{
+    [CmdletBinding()]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $Message,
+
+        [Parameter()]
+        [ValidateNotNull()]
+        [System.Management.Automation.ErrorRecord]
+        $ErrorRecord
+    )
+
+    $newObjectParameters = @{
+        TypeName = 'System.InvalidOperationException'
+    }
+
+    if ($PSBoundParameters.ContainsKey('Message') -and $PSBoundParameters.ContainsKey('ErrorRecord'))
+    {
+        $newObjectParameters['ArgumentList'] = @(
+            $Message,
+            $ErrorRecord.Exception
+        )
+    }
+    elseif ($PSBoundParameters.ContainsKey('Message'))
+    {
+        $newObjectParameters['ArgumentList'] = @(
+            $Message
+        )
+    }
+
+    $invalidOperationException = New-Object @newObjectParameters
+
+    $newObjectParameters = @{
+        TypeName     = 'System.Management.Automation.ErrorRecord'
+        ArgumentList = @(
+            $invalidOperationException.ToString(),
+            'MachineStateIncorrect',
+            'InvalidOperation',
+            $null
+        )
+    }
+
+    return New-Object @newObjectParameters
+}

--- a/source/Public/Get-InvalidResultRecord.ps1
+++ b/source/Public/Get-InvalidResultRecord.ps1
@@ -1,0 +1,59 @@
+<#
+    .SYNOPSIS
+        Returns an invalid result exception object.
+
+    .PARAMETER Message
+        The message explaining why this error is being thrown.
+
+    .PARAMETER ErrorRecord
+        The error record containing the exception that is causing this terminating
+        error.
+#>
+function Get-InvalidResultRecord
+{
+    [CmdletBinding()]
+    [Alias('Get-ObjectNotFoundRecord')]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $Message,
+
+        [Parameter()]
+        [ValidateNotNull()]
+        [System.Management.Automation.ErrorRecord]
+        $ErrorRecord
+    )
+
+    $newObjectParameters = @{
+        TypeName = 'System.Exception'
+    }
+
+    if ($PSBoundParameters.ContainsKey('Message') -and $PSBoundParameters.ContainsKey('ErrorRecord'))
+    {
+        $newObjectParameters['ArgumentList'] = @(
+            $Message,
+            $ErrorRecord.Exception
+        )
+    }
+    elseif ($PSBoundParameters.ContainsKey('Message'))
+    {
+        $newObjectParameters['ArgumentList'] = @(
+            $Message
+        )
+    }
+
+    $invalidOperationException = New-Object @newObjectParameters
+
+    $newObjectParameters = @{
+        TypeName     = 'System.Management.Automation.ErrorRecord'
+        ArgumentList = @(
+            $invalidOperationException.ToString(),
+            'MachineStateIncorrect',
+            'InvalidOperation',
+            $null
+        )
+    }
+
+    return New-Object @newObjectParameters
+}

--- a/source/Public/Wait-ForIdleLcm.ps1
+++ b/source/Public/Wait-ForIdleLcm.ps1
@@ -1,0 +1,33 @@
+<#
+    .SYNOPSIS
+        Waits for LCM to become idle.
+
+    .PARAMETER Clear
+        If specified, the LCM will also be cleared of DSC configurations.
+
+    .NOTES
+        Used in integration test where integration tests run to quickly before
+        LCM have time to cool down.
+#>
+function Wait-ForIdleLcm
+{
+    [CmdletBinding()]
+    param
+    (
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $Clear
+    )
+
+    while ((Get-DscLocalConfigurationManager).LCMState -ne 'Idle')
+    {
+        Write-Verbose -Message 'Waiting for the LCM to become idle'
+
+        Start-Sleep -Seconds 2
+    }
+
+    if ($Clear)
+    {
+        Clear-DscLcmConfiguration
+    }
+}

--- a/tests/Unit/Public/Get-InvalidOperationRecord.Tests.ps1
+++ b/tests/Unit/Public/Get-InvalidOperationRecord.Tests.ps1
@@ -1,0 +1,48 @@
+$ProjectPath = "$PSScriptRoot\..\..\.." | Convert-Path
+$ProjectName = ((Get-ChildItem -Path $ProjectPath\*\*.psd1).Where{
+        ($_.Directory.Name -match 'source|src' -or $_.Directory.Name -eq $_.BaseName) -and
+        $(try
+            {
+                Test-ModuleManifest $_.FullName -ErrorAction Stop
+            }
+            catch
+            {
+                $false
+            } )
+    }).BaseName
+
+Import-Module -Name $ProjectName -Force
+
+Describe 'Get-InvalidOperationRecord' -Tag 'GetInvalidOperationRecord' {
+    Context 'When calling with the parameter Message' {
+        It 'Should have the correct values in the error record' {
+            $result = Get-InvalidOperationRecord -Message 'mocked error message.'
+
+            $result | Should -BeOfType 'System.Management.Automation.ErrorRecord'
+            $result.Exception | Should -BeOfType 'System.Exception'
+            $result.Exception.Message | Should -Be 'System.InvalidOperationException: mocked error message.'
+        }
+    }
+
+    Context 'When calling with the parameters Message and ErrorRecord' {
+        It 'Should have the correct values in the error record' {
+            $result = $null
+
+            try
+            {
+                # Force divide by zero exception.
+                1/0
+            }
+            catch
+            {
+                $result = Get-InvalidOperationRecord -Message 'mocked error message.' -ErrorRecord $_
+            }
+
+            $result | Should -BeOfType 'System.Management.Automation.ErrorRecord'
+            $result.Exception | Should -BeOfType 'System.Exception'
+            $result.Exception.Message -match 'System.InvalidOperationException: mocked error message.' | Should -BeTrue
+            $result.Exception.Message -match 'System.Management.Automation.RuntimeException: Attempted to divide by zero.' | Should -BeTrue
+            $result.Exception.Message -match 'System.DivideByZeroException: Attempted to divide by zero.' | Should -BeTrue
+        }
+    }
+}

--- a/tests/Unit/Public/Get-InvalidResultRecord.Tests.ps1
+++ b/tests/Unit/Public/Get-InvalidResultRecord.Tests.ps1
@@ -1,0 +1,58 @@
+$ProjectPath = "$PSScriptRoot\..\..\.." | Convert-Path
+$ProjectName = ((Get-ChildItem -Path $ProjectPath\*\*.psd1).Where{
+        ($_.Directory.Name -match 'source|src' -or $_.Directory.Name -eq $_.BaseName) -and
+        $(try
+            {
+                Test-ModuleManifest $_.FullName -ErrorAction Stop
+            }
+            catch
+            {
+                $false
+            } )
+    }).BaseName
+
+Import-Module -Name $ProjectName -Force
+
+Describe 'Get-InvalidResultRecord' -Tag 'GetInvalidResultRecord' {
+    Context 'When calling with the parameter Message' {
+        It 'Should have the correct values in the error record' {
+            $result = Get-InvalidResultRecord -Message 'mocked error message.'
+
+            $result | Should -BeOfType 'System.Management.Automation.ErrorRecord'
+            $result.Exception | Should -BeOfType 'System.Exception'
+            $result.Exception.Message | Should -Be 'System.Exception: mocked error message.'
+        }
+    }
+
+    Context 'When calling with the parameters Message and ErrorRecord' {
+        It 'Should have the correct values in the error record' {
+            $result = $null
+
+            try
+            {
+                # Force divide by zero exception.
+                1/0
+            }
+            catch
+            {
+                $result = Get-InvalidResultRecord -Message 'mocked error message.' -ErrorRecord $_
+            }
+
+            $result | Should -BeOfType 'System.Management.Automation.ErrorRecord'
+            $result.Exception | Should -BeOfType 'System.Exception'
+            $result.Exception.Message -match 'System.Exception: mocked error message.' | Should -BeTrue
+            $result.Exception.Message -match 'System.Management.Automation.RuntimeException: Attempted to divide by zero.' | Should -BeTrue
+            $result.Exception.Message -match 'System.DivideByZeroException: Attempted to divide by zero.' | Should -BeTrue
+        }
+    }
+
+    Context 'When calling using the alias Get-ObjectNotFoundRecord' {
+        It 'Should have the correct values in the error record' {
+            $result = Get-ObjectNotFoundRecord -Message 'mocked error message.'
+
+            $result | Should -BeOfType 'System.Management.Automation.ErrorRecord'
+            $result.Exception | Should -BeOfType 'System.Exception'
+            $result.Exception.Message | Should -Be 'System.Exception: mocked error message.'
+        }
+    }
+}

--- a/tests/Unit/Public/Wait-ForIdelLcm.Tests.ps1
+++ b/tests/Unit/Public/Wait-ForIdelLcm.Tests.ps1
@@ -1,0 +1,108 @@
+$ProjectPath = "$PSScriptRoot\..\..\.." | Convert-Path
+$ProjectName = ((Get-ChildItem -Path $ProjectPath\*\*.psd1).Where{
+        ($_.Directory.Name -match 'source|src' -or $_.Directory.Name -eq $_.BaseName) -and
+        $(try
+            {
+                Test-ModuleManifest $_.FullName -ErrorAction Stop
+            }
+            catch
+            {
+                $false
+            } )
+    }).BaseName
+
+Import-Module -Name $ProjectName -Force
+
+Describe 'Wait-ForIdleLcm' -Tag 'WaitForIdleLcm' {
+    BeforeAll {
+        <#
+            Stub for Get-DscLocalConfigurationManager since it is not available
+            cross-platform.
+        #>
+        function Get-DscLocalConfigurationManager
+        {
+            [CmdletBinding()]
+            param ()
+
+            throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+        }
+    }
+
+    AfterAll {
+        Remove-Item -Path 'function:Get-DscLocalConfigurationManager'
+    }
+
+    Context 'When the LCM is idle' {
+        BeforeAll {
+            Mock -CommandName Start-Sleep -ModuleName $ProjectName
+            Mock -CommandName Get-DscLocalConfigurationManager -MockWith {
+                return @{
+                    LCMState = 'Idle'
+                }
+            } -ModuleName $ProjectName
+        }
+
+        It 'Should not throw and call the expected mocks' {
+            { Wait-ForIdleLcm } | Should -Not -Throw
+
+            Assert-MockCalled -CommandName Get-DscLocalConfigurationManager -Exactly -Times 1 -Scope It -ModuleName $ProjectName
+            Assert-MockCalled -CommandName Start-Sleep -Exactly -Times 0 -Scope It -ModuleName $ProjectName
+        }
+    }
+
+    Context 'When waiting for the LCM to become idle' {
+        BeforeAll {
+            Mock -CommandName Start-Sleep -MockWith {
+                $script:mockStartSleepWasCalled = $true
+            } -ModuleName $ProjectName
+
+            Mock -CommandName Get-DscLocalConfigurationManager -MockWith {
+                if ($script:mockStartSleepWasCalled)
+                {
+                    @{
+                        LCMState = 'Idle'
+                    }
+                }
+                else
+                {
+                    @{
+                        LCMState = 'Running'
+                    }
+                }
+
+                return
+            } -ModuleName $ProjectName
+        }
+
+        BeforeEach {
+            $script:mockStartSleepWasCalled = $false
+        }
+
+        It 'Should not throw and call the expected mocks' {
+            { Wait-ForIdleLcm } | Should -Not -Throw
+
+            Assert-MockCalled -CommandName Get-DscLocalConfigurationManager -Exactly -Times 2 -Scope It -ModuleName $ProjectName
+            Assert-MockCalled -CommandName Start-Sleep -Exactly -Times 1 -Scope It -ModuleName $ProjectName
+        }
+    }
+
+    Context 'When the LCM is idle an the LCM should be cleared after' {
+        BeforeAll {
+            Mock -CommandName Start-Sleep -ModuleName $ProjectName
+            Mock -CommandName Clear-DscLcmConfiguration -ModuleName $ProjectName
+            Mock -CommandName Get-DscLocalConfigurationManager -MockWith {
+                return @{
+                    LCMState = 'Idle'
+                }
+            } -ModuleName $ProjectName
+        }
+
+        It 'Should not throw and call the expected mocks' {
+            { Wait-ForIdleLcm -Clear } | Should -Not -Throw
+
+            Assert-MockCalled -CommandName Get-DscLocalConfigurationManager -Exactly -Times 1 -Scope It -ModuleName $ProjectName
+            Assert-MockCalled -CommandName Start-Sleep -Exactly -Times 0 -Scope It -ModuleName $ProjectName
+            Assert-MockCalled -CommandName Clear-DscLcmConfiguration -Exactly -Times 1 -Scope It -ModuleName $ProjectName
+        }
+    }
+}


### PR DESCRIPTION
### Fixed

- Updated cmdlet documentation in README.md.

### Added

- Added test helper functions `Get-InvalidResultRecord` and `Get-InvalidOperationRecord`.
- Added alias `Get-ObjectNotFoundRecord` that points to `Get-InvalidResultRecord`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/dscresource.test/90)
<!-- Reviewable:end -->
