### PR TITLE
Update filters to handle the path seprators correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Now the path separators are handled correctly in the filter functions
+  `WhereModuleFileNotExcluded` and `WhereSourceFileNotExcluded`.
+
 ## [0.14.1] - 2020-11-12
 
 ### Fixed

--- a/source/Private/WhereModuleFileNotExcluded.ps1
+++ b/source/Private/WhereModuleFileNotExcluded.ps1
@@ -1,12 +1,17 @@
 filter WhereModuleFileNotExcluded
 {
-    foreach ($ExclPath in $ExcludeModuleFile)
+    foreach ($excludePath in $ExcludeModuleFile)
     {
-        if ((($filename = $_.FullName) -or ($fileName = $_)) -and $filename -Match ([regex]::Escape($ExclPath)))
+        # Replace any path separator to the one used in the current operating system.
+        $excludePath = $excludePath -replace '\/', [IO.Path]::DirectorySeparatorChar
+        $excludePath = $excludePath -replace '\\', [IO.Path]::DirectorySeparatorChar
+
+        if ((($filename = $_.FullName) -or ($fileName = $_)) -and $filename -match ([regex]::Escape($excludePath)))
         {
-            Write-Debug "Skipping $($_.FullName) because it matches $ExclPath"
+            Write-Debug "Skipping $($_.FullName) because it matches $excludePath"
             return
         }
     }
+
     $_
 }

--- a/source/Private/WhereSourceFileNotExcluded.ps1
+++ b/source/Private/WhereSourceFileNotExcluded.ps1
@@ -1,10 +1,14 @@
 filter WhereSourceFileNotExcluded
 {
-    foreach ($ExclPath in $ExcludeSourceFile)
+    foreach ($excludePath in $ExcludeSourceFile)
     {
-        if ((($filename = $_.FullName) -or ($fileName = $_)) -and $filename -Match ([regex]::Escape($ExclPath)))
+        # Replace any path separator to the one used in the current operating system.
+        $excludePath = $excludePath -replace '\/', [IO.Path]::DirectorySeparatorChar
+        $excludePath = $excludePath -replace '\\', [IO.Path]::DirectorySeparatorChar
+
+        if ((($filename = $_.FullName) -or ($fileName = $_)) -and $filename -Match ([regex]::Escape($excludePath)))
         {
-            Write-Debug "Skipping $($_.FullName) because it matches $ExclPath"
+            Write-Debug "Skipping $($_.FullName) because it matches $excludePath"
             return
         }
     }


### PR DESCRIPTION
- Now the path separators are handled correctly in the filter functions
  `WhereModuleFileNotExcluded` and `WhereSourceFileNotExcluded`.