### PR TITLE
`Wait-ForIdleLcm`: Change wait logic

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,10 +7,33 @@
     "powershell.codeFormatting.whitespaceAroundOperator": true,
     "powershell.codeFormatting.whitespaceAfterSeparator": true,
     "powershell.codeFormatting.ignoreOneLineBlock": false,
+    "powershell.codeFormatting.pipelineIndentationStyle": "IncreaseIndentationForFirstPipeline",
     "powershell.codeFormatting.preset": "Custom",
-    "files.trimTrailingWhitespace": true,
-    "files.insertFinalNewline": true,
+    "powershell.codeFormatting.alignPropertyValuePairs": true,
+    "powershell.developer.bundledModulesPath": "${cwd}/output/RequiredModules",
     "powershell.scriptAnalysis.settingsPath": ".vscode\\analyzersettings.psd1",
+    "powershell.scriptAnalysis.enable": true,
+    "files.trimTrailingWhitespace": true,
+    "files.trimFinalNewlines": true,
+    "files.insertFinalNewline": true,
+    "files.associations": {
+        "*.ps1xml": "xml"
+    },
+    "cSpell.words": [
+        "COMPANYNAME",
+        "ICONURI",
+        "LICENSEURI",
+        "PROJECTURI",
+        "RELEASENOTES",
+        "buildhelpers",
+        "endregion",
+        "gitversion",
+        "icontains",
+        "keepachangelog",
+        "notin",
+        "pscmdlet",
+        "steppable"
+    ],
     "[markdown]": {
         "files.trimTrailingWhitespace": false,
         "files.encoding": "utf8"

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,125 @@
+{
+    "version": "2.0.0",
+    "_runner": "terminal",
+    "windows": {
+        "options": {
+            "shell": {
+                "executable": "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
+                "args": [
+                    "-NoProfile",
+                    "-ExecutionPolicy",
+                    "Bypass",
+                    "-Command"
+                ]
+            }
+        }
+    },
+    "linux": {
+        "options": {
+            "shell": {
+                "executable": "/usr/bin/pwsh",
+                "args": [
+                    "-NoProfile",
+                    "-Command"
+                ]
+            }
+        }
+    },
+    "osx": {
+        "options": {
+            "shell": {
+                "executable": "/usr/local/bin/pwsh",
+                "args": [
+                    "-NoProfile",
+                    "-Command"
+                ]
+            }
+        }
+    },
+    "tasks": [
+        {
+            "label": "build",
+            "type": "shell",
+            "command": "&${cwd}/build.ps1",
+            "args": [],
+            "presentation": {
+                "echo": true,
+                "reveal": "always",
+                "focus": true,
+                "panel": "new",
+                "clear": false
+            },
+            "runOptions": {
+                "runOn": "default"
+            },
+            "problemMatcher": [
+                {
+                    "owner": "powershell",
+                    "fileLocation": [
+                        "absolute"
+                    ],
+                    "severity": "error",
+                    "pattern": [
+                        {
+                            "regexp": "^\\s*(\\[-\\]\\s*.*?)(\\d+)ms\\s*$",
+                            "message": 1
+                        },
+                        {
+                            "regexp": "(.*)",
+                            "code": 1
+                        },
+                        {
+                            "regexp": ""
+                        },
+                        {
+                            "regexp": "^.*,\\s*(.*):\\s*line\\s*(\\d+).*",
+                            "file": 1,
+                            "line": 2
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "label": "test",
+            "type": "shell",
+            "command": "&${cwd}/build.ps1",
+            "args": ["-AutoRestore","-Tasks","test"],
+            "presentation": {
+                "echo": true,
+                "reveal": "always",
+                "focus": true,
+                "panel": "dedicated",
+                "showReuseMessage": true,
+                "clear": false
+            },
+            "problemMatcher": [
+                {
+                    "owner": "powershell",
+                    "fileLocation": [
+                        "absolute"
+                    ],
+                    "severity": "error",
+                    "pattern": [
+                        {
+                            "regexp": "^\\s*(\\[-\\]\\s*.*?)(\\d+)ms\\s*$",
+                            "message": 1
+                        },
+                        {
+                            "regexp": "(.*)",
+                            "code": 1
+                        },
+                        {
+                            "regexp": ""
+                        },
+                        {
+                            "regexp": "^.*,\\s*(.*):\\s*line\\s*(\\d+).*",
+                            "file": 1,
+                            "line": 2
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `Wait-ForIdleLcm`
   - Added new parameter `Timeout` to be able to return after the specified
-    number of seconds ([issue #101](https://github.com/dsccommunity/DscResource.Test/issues/101)).
+    elapsed time ([issue #101](https://github.com/dsccommunity/DscResource.Test/issues/101)).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `Wait-ForIdleLcm`
+  - Added new parameter `Timeout` to be able to return after the specified
+    number of seconds ([issue #101](https://github.com/dsccommunity/DscResource.Test/issues/101)).
+
 ### Changed
 
-- Rename the default branch to `main` ([issue #104](https://github.com/dsccommunity/DscResource.Test/issues/104)).
-- Updated pipeline files.
+- DscResource.Test
+  - Rename the default branch to `main` ([issue #104](https://github.com/dsccommunity/DscResource.Test/issues/104)).
+  - Updated pipeline files.
+- `Wait-ForIdleLcm`
+  - Updated to wait as long as the `LCMState` property has the state `'Busy'` ([issue #101](https://github.com/dsccommunity/DscResource.Test/issues/101)).
+    This will prevent the pipeline to loop indefinitely when an integration
+    test fails and the property `LCMState` is set to `PendingConfiguration`.
 
 ## [0.15.0] - 2021-02-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     This will prevent the pipeline to loop indefinitely when an integration
     test fails and the property `LCMState` is set to `PendingConfiguration`.
 
+### Fixed
+
+- `Invoke_HQRM_Tests`
+  - Fixed the task so it runs together with latest PowerShell module Sampler.
+- `Fail_Build_If_HQRM_Tests_Failed`
+  - Fixed the task so it runs together with latest PowerShell module Sampler.
+
 ## [0.15.0] - 2021-02-09
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Rename the default branch to `main` ([issue #104](https://github.com/dsccommunity/DscResource.Test/issues/104)).
+- Updated pipeline files.
 
 ## [0.15.0] - 2021-02-09
 

--- a/README.md
+++ b/README.md
@@ -491,11 +491,14 @@ Waits for LCM to become idle and optionally clears the LCM by running
 It is meant to be used in integration test where integration tests run to
 quickly before LCM have time to cool down.
 
+It will return if the LCM state is other than 'Busy'. The other states are
+'Idle', 'PendingConfiguration', or 'PendingReboot'.
+
 #### Syntax
 
 <!-- markdownlint-disable MD013 - Line length -->
 ```plaintext
-Wait-ForIdleLcm [-Clear] [<CommonParameters>]
+Wait-ForIdleLcm [[-Timeout] <timespan>] [-Clear] [<CommonParameters>]
 ```
 <!-- markdownlint-enable MD013 - Line length -->
 
@@ -509,7 +512,15 @@ None.
 Wait-ForIdleLcm -Clear
 ```
 
-This will wait for the LCM to become idle and then clear the LCM.
+This will wait for the LCM to return from busy state and then clear the LCM.
+
+```powershell
+Wait-ForIdleLcm -Clear -Timeout '00:00:08'
+```
+
+This will wait for the LCM to return from busy state. If the LCM has not
+returned from busy state within the elapsed time specified in the parameter
+`Timeout` then it will stop waiting and clear the LCM.
 
 ## Tasks
 

--- a/RequiredModules.psd1
+++ b/RequiredModules.psd1
@@ -1,9 +1,9 @@
 @{
-    # Set up a mini virtual environment...
     PSDependOptions             = @{
-        AddToPath  = $True
+        AddToPath  = $true
         Target     = 'output\RequiredModules'
         Parameters = @{
+           Repository = 'PSGallery'
         }
     }
 
@@ -15,6 +15,7 @@
     ModuleBuilder               = 'latest'
     ChangelogManagement         = 'latest'
     Sampler                     = 'latest'
+    'Sampler.GitHubTasks'       = 'latest'
     xDscResourceDesigner        = 'latest'
     MarkdownLinkCheck           = 'latest'
 }

--- a/Resolve-Dependency.ps1
+++ b/Resolve-Dependency.ps1
@@ -1,143 +1,245 @@
-<#PSScriptInfo
+<#
+    .DESCRIPTION
+        Bootstrap script for PSDepend.
 
-.VERSION 0.1.0
+    .PARAMETER DependencyFile
+        Specifies the configuration file for the this script. The default value is
+        'RequiredModules.psd1' relative to this script's path.
 
-.GUID fc162bd7-b649-4398-bff0-180bc473920f
+    .PARAMETER PSDependTarget
+        Path for PSDepend to be bootstrapped and save other dependencies.
+        Can also be CurrentUser or AllUsers if you wish to install the modules in
+        such scope. The default value is './output/RequiredModules' relative to
+        this script's path.
 
-.AUTHOR Gael Colas
+    .PARAMETER Proxy
+        Specifies the URI to use for Proxy when attempting to bootstrap
+        PackageProvider and PowerShellGet.
 
-.COMPANYNAME SynEdgy Ltd
+    .PARAMETER ProxyCredential
+        Specifies the credential to contact the Proxy when provided.
 
-.COPYRIGHT SynEdgy All rights Reserved
+    .PARAMETER Scope
+        Specifies the scope to bootstrap the PackageProvider and PSGet if not available.
+        THe default value is 'CurrentUser'.
 
-.TAGS bootstrap pipeline CI CI/CD
+    .PARAMETER Gallery
+        Specifies the gallery to use when bootstrapping PackageProvider, PSGet and
+        when calling PSDepend (can be overridden in Dependency files). The default
+        value is 'PSGallery'.
 
-.LICENSEURI
+    .PARAMETER GalleryCredential
+        Specifies the credentials to use with the Gallery specified above.
 
-.PROJECTURI https://github.com/gaelcolas/sampler
+    .PARAMETER AllowOldPowerShellGetModule
+        Allow you to use a locally installed version of PowerShellGet older than
+        1.6.0 (not recommended). Default it will install the latest PowerShellGet
+        if an older version than 2.0 is detected.
 
-.RELEASENOTES
- # This is where the ChangeLog should be
+    .PARAMETER MinimumPSDependVersion
+        Allow you to specify a minimum version fo PSDepend, if you're after specific
+        features.
 
+    .PARAMETER AllowPrerelease
+        Not yet written.
+
+    .PARAMETER WithYAML
+        Not yet written.
+
+    .NOTES
+        Load defaults for parameters values from Resolve-Dependency.psd1 if not
+        provided as parameter.
 #>
 [CmdletBinding()]
-param(
+param
+(
+    [Parameter()]
+    [System.String]
+    $DependencyFile = 'RequiredModules.psd1',
 
-    [String]$DependencyFile = 'RequiredModules.psd1',
+    [Parameter()]
+    [System.String]
+    $PSDependTarget = (Join-Path -Path $PSScriptRoot -ChildPath './output/RequiredModules'),
 
-    # Path for PSDepend to be bootstrapped and save other dependencies.
-    # Can also be CurrentUser or AllUsers if you wish to install the modules in such scope
-    # Default to $PWD.Path/output/modules
-    $PSDependTarget = (Join-Path $PSScriptRoot './output/RequiredModules'),
+    [Parameter()]
+    [System.Uri]
+    $Proxy,
 
-    # URI to use for Proxy when attempting to Bootstrap PackageProvider & PowerShellGet
-    [uri]$Proxy,
+    [Parameter()]
+    [System.Management.Automation.PSCredential]
+    $ProxyCredential,
 
-    # Credential to contact the Proxy when provided
-    [PSCredential]$ProxyCredential,
-
-    # Scope to bootstrap the PackageProvider and PSGet if not available
+    [Parameter()]
     [ValidateSet('CurrentUser', 'AllUsers')]
+    [System.String]
     $Scope = 'CurrentUser',
 
-    # Gallery to use when bootstrapping PackageProvider, PSGet and when calling PSDepend (can be overridden in Dependency files)
-    [String]$Gallery = 'PSGallery',
-
-    # Credentials to use with the Gallery specified above
     [Parameter()]
-    [PSCredential]$GalleryCredential,
+    [System.String]
+    $Gallery = 'PSGallery',
 
+    [Parameter()]
+    [System.Management.Automation.PSCredential]
+    $GalleryCredential,
 
-    # Allow you to use a locally installed version of PowerShellGet older than 1.6.0 (not recommended, default to $False)
-    [switch]$AllowOldPowerShellGetModule,
+    [Parameter()]
+    [System.Management.Automation.SwitchParameter]
+    $AllowOldPowerShellGetModule,
 
-    # Allow you to specify a minimum version fo PSDepend, if you're after specific features.
-    [String]$MinimumPSDependVersion,
+    [Parameter()]
+    [System.String]
+    $MinimumPSDependVersion,
 
-    [Switch]$AllowPrerelease,
+    [Parameter()]
+    [System.Management.Automation.SwitchParameter]
+    $AllowPrerelease,
 
-    [Switch]$WithYAML
+    [Parameter()]
+    [System.Management.Automation.SwitchParameter]
+    $WithYAML
 )
 
-# Load Defaults for parameters values from Resolve-Dependency.psd1 if not provided as parameter
-try {
-    Write-Verbose -Message "Importing Bootstrap default parameters from '$PSScriptRoot/Resolve-Dependency.psd1'."
-    $ResolveDependencyDefaults = Import-PowerShellDataFile -Path (Join-Path $PSScriptRoot '.\Resolve-Dependency.psd1' -Resolve -ErrorAction Stop)
-    $ParameterToDefault = $MyInvocation.MyCommand.ParameterSets.Where{ $_.Name -eq $PSCmdlet.ParameterSetName}.Parameters.Keys
-    if ($ParameterToDefault.Count -eq 0) {
-        $ParameterToDefault = $MyInvocation.MyCommand.Parameters.Keys
+try
+{
+    if ($PSVersionTable.PSVersion.Major -le 5)
+    {
+        if (-not (Get-Command -Name 'Import-PowerShellDataFile' -ErrorAction 'SilentlyContinue'))
+        {
+            Import-Module -Name Microsoft.PowerShell.Utility -RequiredVersion '3.1.0.0'
+        }
+
+        <#
+            Making sure the imported PackageManagement module is not from PS7 module
+            path. The VSCode PS extension is changing the $env:PSModulePath and
+            prioritize the PS7 path. This is an issue with PowerShellGet because
+            it loads an old version if available (or fail to load latest).
+        #>
+        Get-Module -ListAvailable PackageManagement |
+            Where-Object -Property 'ModuleBase' -NotMatch 'powershell.7' |
+            Select-Object -First 1 |
+            Import-Module -Force
     }
-    # Set the parameters available in the Parameter Set, or it's not possible to choose yet, so all parameters are an option
-    foreach ($ParamName in $ParameterToDefault) {
-        if (-Not $PSBoundParameters.Keys.Contains($ParamName) -and $ResolveDependencyDefaults.ContainsKey($ParamName)) {
-            Write-Verbose -Message "Setting $ParamName with $($ResolveDependencyDefaults[$ParamName])"
-            try {
-                $variableValue = $ResolveDependencyDefaults[$ParamName]
-                if($variableValue -is [string]) {
+
+    Write-Verbose -Message 'Importing Bootstrap default parameters from ''$PSScriptRoot/Resolve-Dependency.psd1''.'
+
+    $resolveDependencyConfigPath = Join-Path -Path $PSScriptRoot -ChildPath '.\Resolve-Dependency.psd1' -Resolve -ErrorAction 'Stop'
+
+    $resolveDependencyDefaults = Import-PowerShellDataFile -Path $resolveDependencyConfigPath
+
+    $parameterToDefault = $MyInvocation.MyCommand.ParameterSets.Where{ $_.Name -eq $PSCmdlet.ParameterSetName }.Parameters.Keys
+
+    if ($parameterToDefault.Count -eq 0)
+    {
+        $parameterToDefault = $MyInvocation.MyCommand.Parameters.Keys
+    }
+
+    # Set the parameters available in the Parameter Set, or it's not possible to choose yet, so all parameters are an option.
+    foreach ($parameterName in $parameterToDefault)
+    {
+        if (-not $PSBoundParameters.Keys.Contains($parameterName) -and $resolveDependencyDefaults.ContainsKey($parameterName))
+        {
+            Write-Verbose -Message "Setting $parameterName with $($resolveDependencyDefaults[$parameterName])."
+
+            try
+            {
+                $variableValue = $resolveDependencyDefaults[$parameterName]
+
+                if ($variableValue -is [System.String])
+                {
                     $variableValue = $ExecutionContext.InvokeCommand.ExpandString($variableValue)
                 }
-                $PSBoundParameters.Add($ParamName, $variableValue)
-                Set-Variable -Name $ParamName -value $variableValue -Force -ErrorAction SilentlyContinue
+
+                $PSBoundParameters.Add($parameterName, $variableValue)
+
+                Set-Variable -Name $parameterName -value $variableValue -Force -ErrorAction 'SilentlyContinue'
             }
-            catch {
-                Write-Verbose -Message "Error adding default for $ParamName : $($_.Exception.Message)"
+            catch
+            {
+                Write-Verbose -Message "Error adding default for $parameterName : $($_.Exception.Message)."
             }
         }
     }
 }
-catch {
-    Write-Warning -Message "Error attempting to import Bootstrap's default parameters from $(Join-Path $PSScriptRoot '.\Resolve-Dependency.psd1'): $($_.Exception.Message)."
+catch
+{
+    Write-Warning -Message "Error attempting to import Bootstrap's default parameters from '$resolveDependencyConfigPath': $($_.Exception.Message)."
 }
 
-Write-Progress -Activity "Bootstrap:" -PercentComplete 0 -CurrentOperation "NuGet Bootstrap"
+Write-Progress -Activity 'Bootstrap:' -PercentComplete 0 -CurrentOperation 'NuGet Bootstrap'
 
-if (!(Get-PackageProvider -Name NuGet -ForceBootstrap -ErrorAction SilentlyContinue)) {
-    $providerBootstrapParams = @{
+# TODO: This should handle the parameter $AllowOldPowerShellGetModule.
+$powerShellGetModule = Import-Module -Name 'PowerShellGet' -MinimumVersion '2.0' -ErrorAction 'SilentlyContinue' -PassThru
+
+# Install the package provider if it is not available.
+$nuGetProvider = Get-PackageProvider -Name 'NuGet' -ListAvailable | Select-Object -First 1
+
+if (-not $powerShellGetModule -and -not $nuGetProvider)
+{
+    $providerBootstrapParameters = @{
         Name           = 'nuget'
-        force          = $true
+        Force          = $true
         ForceBootstrap = $true
         ErrorAction    = 'Stop'
     }
 
-    switch ($PSBoundParameters.Keys) {
-        'Proxy' {
-            $providerBootstrapParams.Add('Proxy', $Proxy)
+    switch ($PSBoundParameters.Keys)
+    {
+        'Proxy'
+        {
+            $providerBootstrapParameters.Add('Proxy', $Proxy)
         }
-        'ProxyCredential' {
-            $providerBootstrapParams.Add('ProxyCredential', $ProxyCredential)
+
+        'ProxyCredential'
+        {
+            $providerBootstrapParameters.Add('ProxyCredential', $ProxyCredential)
         }
-        'Scope' {
-            $providerBootstrapParams.Add('Scope', $Scope)
+
+        'Scope'
+        {
+            $providerBootstrapParameters.Add('Scope', $Scope)
         }
     }
 
-    if ($AllowPrerelease) {
-        $providerBootstrapParams.Add('AllowPrerelease', $true)
+    if ($AllowPrerelease)
+    {
+        $providerBootstrapParameters.Add('AllowPrerelease', $true)
     }
 
-    Write-Information "Bootstrap: Installing NuGet Package Provider from the web (Make sure Microsoft addresses/ranges are allowed)"
+    Write-Information -MessageData 'Bootstrap: Installing NuGet Package Provider from the web (Make sure Microsoft addresses/ranges are allowed).'
+
     $null = Install-PackageProvider @providerBootstrapParams
-    $latestNuGetVersion = (Get-PackageProvider -Name NuGet -ListAvailable | Select-Object -First 1).Version.ToString()
-    Write-Information "Bootstrap: Importing NuGet Package Provider version $latestNuGetVersion to current session."
-    $Null = Import-PackageProvider -Name NuGet -RequiredVersion $latestNuGetVersion -Force
+
+    $nuGetProvider = Get-PackageProvider -Name 'NuGet' -ListAvailable | Select-Object -First 1
+
+    $nuGetProviderVersion = $nuGetProvider.Version.ToString()
+
+    Write-Information -MessageData "Bootstrap: Importing NuGet Package Provider version $nuGetProviderVersion to current session."
+
+    $Null = Import-PackageProvider -Name 'NuGet' -RequiredVersion $nuGetProviderVersion -Force
 }
 
-Write-Progress -Activity "Bootstrap:" -PercentComplete 10 -CurrentOperation "Ensuring Gallery $Gallery is trusted"
+Write-Progress -Activity 'Bootstrap:' -PercentComplete 10 -CurrentOperation "Ensuring Gallery $Gallery is trusted"
 
-# Fail if the given PSGallery is not Registered
-$Policy = (Get-PSRepository $Gallery -ErrorAction Stop).InstallationPolicy
-Set-PSRepository -Name $Gallery -InstallationPolicy Trusted -ErrorAction Ignore
-try {
+# Fail if the given PSGallery is not registered.
+$previousGalleryInstallationPolicy = (Get-PSRepository -Name $Gallery -ErrorAction 'Stop').InstallationPolicy
 
-    Write-Progress -Activity "Bootstrap:" -PercentComplete 25 -CurrentOperation "Checking PowerShellGet"
-    # Ensure the module is loaded and retrieve the version you have
-    $PowerShellGetVersion = (Import-Module PowerShellGet -PassThru -ErrorAction SilentlyContinue).Version
+Set-PSRepository -Name $Gallery -InstallationPolicy 'Trusted' -ErrorAction 'Ignore'
 
-    Write-Verbose "Bootstrap: The PowerShellGet version is $PowerShellGetVersion"
-    # Versions below 1.6.0 are considered old, unreliable & not recommended
-    if (!$PowerShellGetVersion -or ($PowerShellGetVersion -lt [System.version]'1.6.0' -and !$AllowOldPowerShellGetModule)) {
-        Write-Progress -Activity "Bootstrap:" -PercentComplete 40 -CurrentOperation "Installing newer version of PowerShellGet"
-        $InstallPSGetParam = @{
+try
+{
+    Write-Progress -Activity 'Bootstrap:' -PercentComplete 25 -CurrentOperation 'Checking PowerShellGet'
+
+    # Ensure the module is loaded and retrieve the version you have.
+    $powerShellGetVersion = (Import-Module -Name 'PowerShellGet' -PassThru -ErrorAction 'SilentlyContinue').Version
+
+    Write-Verbose -Message "Bootstrap: The PowerShellGet version is $powerShellGetVersion"
+
+    # Versions below 2.0 are considered old, unreliable & not recommended
+    if (-not $powerShellGetVersion -or ($powerShellGetVersion -lt [System.Version] '2.0' -and -not $AllowOldPowerShellGetModule))
+    {
+        Write-Progress -Activity 'Bootstrap:' -PercentComplete 40 -CurrentOperation 'Installing newer version of PowerShellGet'
+
+        $installPowerShellGetParameters = @{
             Name               = 'PowerShellGet'
             Force              = $True
             SkipPublisherCheck = $true
@@ -146,45 +248,61 @@ try {
             Repository         = $Gallery
         }
 
-        switch ($PSBoundParameters.Keys) {
-            'Proxy' {
-                $InstallPSGetParam.Add('Proxy', $Proxy)
+        switch ($PSBoundParameters.Keys)
+        {
+            'Proxy'
+            {
+                $installPowerShellGetParameters.Add('Proxy', $Proxy)
             }
-            'ProxyCredential' {
-                $InstallPSGetParam.Add('ProxyCredential', $ProxyCredential)
+
+            'ProxyCredential'
+            {
+                $installPowerShellGetParameters.Add('ProxyCredential', $ProxyCredential)
             }
-            'GalleryCredential' {
-                $InstallPSGetParam.Add('Credential', $GalleryCredential)
+
+            'GalleryCredential'
+            {
+                $installPowerShellGetParameters.Add('Credential', $GalleryCredential)
             }
         }
 
-        Install-Module @InstallPSGetParam
-        Remove-Module PowerShellGet -force -ErrorAction SilentlyContinue
-        Import-Module PowerShellGet -Force
-        $NewLoadedVersion = (Get-Module PowerShellGet).Version.ToString()
-        Write-Information "Bootstrap: PowerShellGet version loaded is $NewLoadedVersion"
-        Write-Progress -Activity "Bootstrap:" -PercentComplete 60 -CurrentOperation "Installing newer version of PowerShellGet"
+        Write-Progress -Activity 'Bootstrap:' -PercentComplete 60 -CurrentOperation 'Installing newer version of PowerShellGet'
+
+        Install-Module @installPowerShellGetParameters
+
+        Remove-Module -Name 'PowerShellGet' -Force -ErrorAction 'SilentlyContinue'
+        Remove-Module -Name 'PackageManagement' -Force
+
+        $powerShellGetModule = Import-Module PowerShellGet -Force -PassThru
+
+        $powerShellGetVersion = $powerShellGetModule.Version.ToString()
+
+        Write-Information -MessageData "Bootstrap: PowerShellGet version loaded is $powerShellGetVersion"
     }
 
-    # Try to import the PSDepend module from the available modules
-    try {
-        $ImportPSDependParam = @{
-            Name        = 'PSDepend'
-            ErrorAction = 'Stop'
-            Force       = $true
-        }
-
-        if ($MinimumPSDependVersion) {
-            $ImportPSDependParam.add('MinimumVersion', $MinimumPSDependVersion)
-        }
-        $null = Import-Module @ImportPSDependParam
+    # Try to import the PSDepend module from the available modules.
+    $getModuleParameters = @{
+        Name          = 'PSDepend'
+        ListAvailable = $true
     }
-    catch {
-        # PSDepend module not found, installing or saving it
-        if ($PSDependTarget -in 'CurrentUser', 'AllUsers') {
-            Write-Debug "PSDepend module not found. Attempting to install from Gallery $Gallery"
-            Write-Warning "Installing PSDepend in $PSDependTarget Scope"
-            $InstallPSDependParam = @{
+
+    $psDependModule = Get-Module @getModuleParameters
+
+    if ($PSBoundParameters.ContainsKey('MinimumPSDependVersion'))
+    {
+        $psDependModule = $psDependModule | Where-Object -Property -eq $MinimumPSDependVersion
+    }
+
+    if (-not $psDependModule)
+    {
+        # PSDepend module not found, installing or saving it.
+        if ($PSDependTarget -in 'CurrentUser', 'AllUsers')
+        {
+            Write-Debug -Message "PSDepend module not found. Attempting to install from Gallery $Gallery."
+
+            Write-Warning -Message "Installing PSDepend in $PSDependTarget Scope."
+
+            $installPSDependParameters = @{
                 Name               = 'PSDepend'
                 Repository         = $Gallery
                 Force              = $true
@@ -193,38 +311,62 @@ try {
                 AllowClobber       = $true
             }
 
-            if ($MinimumPSDependVersion) {
-                $InstallPSDependParam.add('MinimumVersion', $MinimumPSDependVersion)
+            if ($MinimumPSDependVersion)
+            {
+                $installPSDependParameters.Add('MinimumVersion', $MinimumPSDependVersion)
             }
 
-            Write-Progress -Activity "Bootstrap:" -PercentComplete 75 -CurrentOperation "Installing PSDepend from $Gallery"
-            Install-Module @InstallPSDependParam
+            Write-Progress -Activity 'Bootstrap:' -PercentComplete 75 -CurrentOperation "Installing PSDepend from $Gallery"
+
+            Install-Module @installPSDependParameters
         }
-        else {
-            Write-Debug "PSDepend module not found. Attempting to Save from Gallery $Gallery to $PSDependTarget"
-            $SaveModuleParam = @{
+        else
+        {
+            Write-Debug -Message "PSDepend module not found. Attempting to Save from Gallery $Gallery to $PSDependTarget"
+
+            $saveModuleParameters = @{
                 Name       = 'PSDepend'
                 Repository = $Gallery
                 Path       = $PSDependTarget
             }
 
-            if ($MinimumPSDependVersion) {
-                $SaveModuleParam.add('MinimumVersion', $MinimumPSDependVersion)
+            if ($MinimumPSDependVersion)
+            {
+                $saveModuleParameters.add('MinimumVersion', $MinimumPSDependVersion)
             }
 
-            Write-Progress -Activity "Bootstrap:" -PercentComplete 75 -CurrentOperation "Saving & Importing PSDepend from $Gallery to $Scope"
-            Save-Module @SaveModuleParam
+            Write-Progress -Activity 'Bootstrap:' -PercentComplete 75 -CurrentOperation "Saving & Importing PSDepend from $Gallery to $Scope"
+
+            Save-Module @saveModuleParameters
         }
     }
-    finally {
-        Write-Progress -Activity "Bootstrap:" -PercentComplete 100 -CurrentOperation "Loading PSDepend"
-        # We should have successfully bootstrapped PSDepend. Fail if not available
-        Import-Module PSDepend -ErrorAction Stop
+
+    Write-Progress -Activity 'Bootstrap:' -PercentComplete 80 -CurrentOperation 'Loading PSDepend'
+
+    $importModulePSDependParameters = @{
+        Name        = 'PSDepend'
+        ErrorAction = 'Stop'
+        Force       = $true
     }
 
-    if ($WithYAML) {
-        if (-Not (Get-Module -ListAvailable -Name 'PowerShell-Yaml')) {
-            Write-Verbose "PowerShell-Yaml module not found. Attempting to Save from Gallery $Gallery to $PSDependTarget"
+    if ($PSBoundParameters.ContainsKey('MinimumPSDependVersion'))
+    {
+        $importModulePSDependParameters.Add('MinimumVersion', $MinimumPSDependVersion)
+    }
+
+    # We should have successfully bootstrapped PSDepend. Fail if not available.
+    $null = Import-Module @importModulePSDependParameters
+
+    if ($WithYAML)
+    {
+        Write-Progress -Activity 'Bootstrap:' -PercentComplete 82 -CurrentOperation 'Verifying PowerShell module PowerShell-Yaml'
+
+        if (-not (Get-Module -ListAvailable -Name 'PowerShell-Yaml'))
+        {
+            Write-Progress -Activity 'Bootstrap:' -PercentComplete 85 -CurrentOperation 'Installing PowerShell module PowerShell-Yaml'
+
+            Write-Verbose -Message "PowerShell-Yaml module not found. Attempting to Save from Gallery $Gallery to $PSDependTarget"
+
             $SaveModuleParam = @{
                 Name       = 'PowerShell-Yaml'
                 Repository = $Gallery
@@ -232,27 +374,39 @@ try {
             }
 
             Save-Module @SaveModuleParam
-            Import-Module "PowerShell-Yaml" -ErrorAction Stop
         }
-        else {
+        else
+        {
             Write-Verbose "PowerShell-Yaml is already available"
         }
+
+        Write-Progress -Activity 'Bootstrap:' -PercentComplete 88 -CurrentOperation 'Importing PowerShell module PowerShell-Yaml'
+
+        Import-Module -Name 'PowerShell-Yaml' -ErrorAction 'Stop'
     }
 
+    Write-Progress -Activity 'Bootstrap:' -PercentComplete 90 -CurrentOperation 'Invoke PSDepend'
+
     Write-Progress -Activity "PSDepend:" -PercentComplete 0 -CurrentOperation "Restoring Build Dependencies"
-    if (Test-Path $DependencyFile) {
-        $PSDependParams = @{
+
+    if (Test-Path -Path $DependencyFile)
+    {
+        $psDependParameters = @{
             Force = $true
             Path  = $DependencyFile
         }
 
-        # TODO: Handle when the Dependency file is in YAML, and -WithYAML is specified
-        Invoke-PSDepend @PSDependParams
+        # TODO: Handle when the Dependency file is in YAML, and -WithYAML is specified.
+        Invoke-PSDepend @psDependParameters
     }
+
     Write-Progress -Activity "PSDepend:" -PercentComplete 100 -CurrentOperation "Dependencies restored" -Completed
+
+    Write-Progress -Activity 'Bootstrap:' -PercentComplete 100 -CurrentOperation "Bootstrap complete" -Completed
 }
-finally {
+finally
+{
     # Reverting the Installation Policy for the given gallery
-    Set-PSRepository -Name $Gallery -InstallationPolicy $Policy
-    Write-Verbose "Project Bootstrapped, returning to Invoke-Build"
+    Set-PSRepository -Name $Gallery -InstallationPolicy $previousGalleryInstallationPolicy
+    Write-Verbose -Message "Project Bootstrapped, returning to Invoke-Build"
 }

--- a/Resolve-Dependency.psd1
+++ b/Resolve-Dependency.psd1
@@ -1,10 +1,6 @@
-@{ # Defaults Parameter value to be loaded by the Resolve-Dependency command (unless set in Bound Parameters)
-    #PSDependTarget  = './output/modules'
-    #Proxy = ''
-    #ProxyCredential = '$MyCredentialVariable' #TODO: find a way to support credentials in build (resolve variable)
+@{
     Gallery         = 'PSGallery'
-    # AllowOldPowerShellGetModule = $true
-    #MinimumPSDependVersion = '0.3.0'
     AllowPrerelease = $false
     WithYAML        = $true # Will also bootstrap PowerShell-Yaml to read other config files
 }
+

--- a/build.ps1
+++ b/build.ps1
@@ -1,283 +1,418 @@
 <#
+    .DESCRIPTION
+        Bootstrap and build script for PowerShell module CI/CD pipeline
 
-.DESCRIPTION
- Bootstrap and build script for PowerShell module pipeline
+    .PARAMETER Tasks
+        The task or tasks to run. The default value is '.' (runs the default task).
 
+    .PARAMETER CodeCoverageThreshold
+        The code coverage target threshold to uphold. Set to 0 to disable.
+        The default value is '' (empty string).
+
+    .PARAMETER BuildConfig
+        Not yet written.
+
+    .PARAMETER OutputDirectory
+        Specifies the folder to build the artefact into. The default value is 'output'.
+
+    .PARAMETER BuiltModuleSubdirectory
+        Subdirectory name to build the module (under $OutputDirectory). The default
+        value is '' (empty string).
+
+    .PARAMETER RequiredModulesDirectory
+        Can be a path (relative to $PSScriptRoot or absolute) to tell Resolve-Dependency
+        and PSDepend where to save the required modules. It is also possible to use
+        'CurrentUser' och 'AllUsers' to install missing dependencies. You can override
+        the value for PSDepend in the Build.psd1 build manifest. The default value is
+        'output/RequiredModules'.
+
+    .PARAMETER PesterScript
+        One or more paths that will override the Pester configuration in build
+        configuration file when running the build task Invoke_Pester_Tests.
+
+        If running Pester 5 test, use the alias PesterPath to be future-proof.
+
+    .PARAMETER PesterTag
+        Filter which tags to run when invoking Pester tests. This is used in the
+        Invoke-Pester.pester.build.ps1 tasks.
+
+    .PARAMETER PesterExcludeTag
+        Filter which tags to exclude when invoking Pester tests. This is used in
+        the Invoke-Pester.pester.build.ps1 tasks.
+
+    .PARAMETER DscTestTag
+        Filter which tags to run when invoking DSC Resource tests. This is used
+        in the DscResource.Test.build.ps1 tasks.
+
+    .PARAMETER DscTestExcludeTag
+        Filter which tags to exclude when invoking DSC Resource tests. This is
+        used in the DscResource.Test.build.ps1 tasks.
+
+    .PARAMETER ResolveDependency
+        Not yet written.
+
+    .PARAMETER BuildInfo
+        The build info object from ModuleBuilder. Defaults to an empty hashtable.
+
+    .PARAMETER AutoRestore
+        Not yet written.
 #>
 [CmdletBinding()]
 param
 (
     [Parameter(Position = 0)]
-    [string[]]$Tasks = '.',
+    [System.String[]]
+    $Tasks = '.',
 
     [Parameter()]
-    [String]
+    [System.String]
     $CodeCoverageThreshold = '',
 
     [Parameter()]
-    [validateScript(
+    [System.String]
+    [ValidateScript(
         { Test-Path -Path $_ }
     )]
-    $BuildConfig = './build.yaml',
+    $BuildConfig,
 
     [Parameter()]
-    # A Specific folder to build the artefact into.
+    [System.String]
     $OutputDirectory = 'output',
 
     [Parameter()]
-    # Subdirectory name to build the module (under $OutputDirectory)
+    [System.String]
     $BuiltModuleSubdirectory = '',
 
-    # Can be a path (relative to $PSScriptRoot or absolute) to tell Resolve-Dependency & PSDepend where to save the required modules,
-    # or use CurrentUser, AllUsers to target where to install missing dependencies
-    # You can override the value for PSDepend in the Build.psd1 build manifest
-    # This defaults to $OutputDirectory/modules (by default: ./output/modules)
     [Parameter()]
+    [System.String]
     $RequiredModulesDirectory = $(Join-Path 'output' 'RequiredModules'),
 
-    # Filter which tags to run when invoking Pester tests
-    # This is used in the Invoke-Pester.pester.build.ps1 tasks
     [Parameter()]
-    [string[]]
+    # This alias is to prepare for the rename of this parameter to PesterPath when Pester 4 support is removed
+    [Alias('PesterPath')]
+    [System.Object[]]
+    $PesterScript,
+
+    [Parameter()]
+    [System.String[]]
     $PesterTag,
 
     [Parameter()]
-    [string[]]
-    $PesterScript,
-
-    # Filter which tags to exclude when invoking Pester tests
-    # This is used in the Invoke-Pester.pester.build.ps1 tasks
-    [Parameter()]
-    [string[]]
+    [System.String[]]
     $PesterExcludeTag,
 
     [Parameter()]
+    [System.String[]]
+    $DscTestTag,
+
+    [Parameter()]
+    [System.String[]]
+    $DscTestExcludeTag,
+
+    [Parameter()]
     [Alias('bootstrap')]
-    [switch]$ResolveDependency,
+    [System.Management.Automation.SwitchParameter]
+    $ResolveDependency,
 
     [Parameter(DontShow)]
     [AllowNull()]
+    [System.Collections.Hashtable]
     $BuildInfo,
 
     [Parameter()]
-    [switch]
+    [System.Management.Automation.SwitchParameter]
     $AutoRestore
 )
 
-# The BEGIN block (at the end of this file) handles the Bootstrap of the Environment before Invoke-Build can run the tasks
-# if the -ResolveDependency (aka Bootstrap) is specified, the modules are already available, and can be auto loaded
+<#
+    The BEGIN block (at the end of this file) handles the Bootstrap of the Environment
+    before Invoke-Build can run the tasks if the parameter ResolveDependency (or
+    parameter alias Bootstrap) is specified.
+#>
 
 process
 {
 
     if ($MyInvocation.ScriptName -notLike '*Invoke-Build.ps1')
     {
-        # Only run the process block through InvokeBuild (Look at the Begin block at the bottom of this script)
+        # Only run the process block through InvokeBuild (look at the Begin block at the bottom of this script).
         return
     }
 
-    # Execute the Build Process from the .build.ps1 path.
-    Push-Location -Path $PSScriptRoot -StackName BeforeBuild
+    # Execute the Build process from the .build.ps1 path.
+    Push-Location -Path $PSScriptRoot -StackName 'BeforeBuild'
 
     try
     {
-        Write-Host -ForeGroundColor magenta "[build] Parsing defined tasks"
+        Write-Host -Object "[build] Parsing defined tasks" -ForeGroundColor Magenta
 
-        # Load Default BuildInfo if not provided as parameter
-        if (!$PSBoundParameters.ContainsKey('BuildInfo'))
+        # Load the default BuildInfo if the parameter BuildInfo is not set.
+        if (-not $PSBoundParameters.ContainsKey('BuildInfo'))
         {
             try
             {
-                if (Test-Path $BuildConfig)
+                if (Test-Path -Path $BuildConfig)
                 {
-                    $ConfigFile = (Get-Item -Path $BuildConfig)
-                    Write-Host "[build] Loading Configuration from $ConfigFile"
-                    $BuildInfo = switch -Regex ($ConfigFile.Extension)
+                    $configFile = Get-Item -Path $BuildConfig
+
+                    Write-Host -Object "[build] Loading Configuration from $configFile"
+
+                    $BuildInfo = switch -Regex ($configFile.Extension)
                     {
                         # Native Support for PSD1
                         '\.psd1'
                         {
+                            if (-not (Get-Command -Name Import-PowerShellDataFile -ErrorAction SilentlyContinue))
+                            {
+                                Import-Module -Name Microsoft.PowerShell.Utility -RequiredVersion 3.1.0.0
+                            }
+
                             Import-PowerShellDataFile -Path $BuildConfig
                         }
+
                         # Support for yaml when module PowerShell-Yaml is available
                         '\.[yaml|yml]'
                         {
-                            Import-Module -ErrorAction Stop -Name 'powershell-yaml'
-                            ConvertFrom-Yaml -Yaml (Get-Content -Raw $ConfigFile)
+                            Import-Module -Name 'powershell-yaml' -ErrorAction Stop
+
+                            ConvertFrom-Yaml -Yaml (Get-Content -Raw $configFile)
                         }
+
                         # Native Support for JSON and JSONC (by Removing comments)
                         '\.[json|jsonc]'
                         {
-                            $JSONC = (Get-Content -Raw -Path $ConfigFile)
-                            $JSON = $JSONC -replace '(?m)\s*//.*?$' -replace '(?ms)/\*.*?\*/'
-                            # This should probably be converted to hashtable for splatting
-                            $JSON | ConvertFrom-Json
+                            $jsonFile = Get-Content -Raw -Path $configFile
+
+                            $jsonContent = $jsonFile -replace '(?m)\s*//.*?$' -replace '(?ms)/\*.*?\*/'
+
+                            # Yaml is superset of JSON.
+                            ConvertFrom-Yaml -Yaml $jsonContent
                         }
+
+                        # Unknown extension, return empty hashtable.
                         default
                         {
-                            Write-Error "Extension '$_' not supported. using @{}"
+                            Write-Error -Message "Extension '$_' not supported. using @{}"
+
                             @{ }
                         }
                     }
                 }
                 else
                 {
-                    Write-Host -Object "Configuration file $BuildConfig not found" -ForegroundColor Red
+                    Write-Host -Object "Configuration file '$($BuildConfig.FullName)' not found" -ForegroundColor Red
+
+                    # No config file was found, return empty hashtable.
                     $BuildInfo = @{ }
                 }
             }
             catch
             {
-                Write-Host -Object "Error loading Config $ConfigFile.`r`n Are you missing dependencies?" -ForegroundColor Yellow
-                Write-Host -Object "Make sure you run './build.ps1 -ResolveDependency -tasks noop' to restore the Required modules the first time" -ForegroundColor Yellow
+                $logMessage = "Error loading Config '$($BuildConfig.FullName)'.`r`nAre you missing dependencies?`r`nMake sure you run './build.ps1 -ResolveDependency -tasks noop' before running build to restore the required modules."
+
+                Write-Host -Object $logMessage -ForegroundColor Yellow
+
                 $BuildInfo = @{ }
-                Write-Error $_.Exception.Message
+
+                Write-Error -Message $_.Exception.Message
             }
         }
 
-        # If the Invoke-Build Task Header is specified in the Build Info, set it
+        # If the Invoke-Build Task Header is specified in the Build Info, set it.
         if ($BuildInfo.TaskHeader)
         {
-            Set-BuildHeader ([scriptblock]::Create($BuildInfo.TaskHeader))
+            Set-BuildHeader -Script ([scriptblock]::Create($BuildInfo.TaskHeader))
         }
 
-        # Import Tasks from modules via their exported aliases when defined in BUild Manifest
-        # https://github.com/nightroman/Invoke-Build/tree/master/Tasks/Import#example-2-import-from-a-module-with-tasks
-        if ($BuildInfo.containsKey('ModuleBuildTasks'))
+        <#
+            Import Tasks from modules via their exported aliases when defined in Build Manifest.
+            https://github.com/nightroman/Invoke-Build/tree/master/Tasks/Import#example-2-import-from-a-module-with-tasks
+        #>
+        if ($BuildInfo.ContainsKey('ModuleBuildTasks'))
         {
-            foreach ($Module in $BuildInfo['ModuleBuildTasks'].Keys)
+            foreach ($module in $BuildInfo['ModuleBuildTasks'].Keys)
             {
                 try
                 {
-                    Write-Host -ForegroundColor DarkGray -Verbose "Importing tasks from module $Module"
-                    $LoadedModule = Import-Module $Module -PassThru -ErrorAction Stop
-                    foreach ($TaskToExport in $BuildInfo['ModuleBuildTasks'].($Module))
+                    Write-Host -Object "Importing tasks from module $module" -ForegroundColor DarkGray
+
+                    $loadedModule = Import-Module -Name $module -PassThru -ErrorAction Stop
+
+                    foreach ($TaskToExport in $BuildInfo['ModuleBuildTasks'].($module))
                     {
-                        $LoadedModule.ExportedAliases.GetEnumerator().Where{
-                            # using -like to support wildcard
-                            Write-Host -ForegroundColor DarkGray "`t Loading $($_.Key)..."
+                        $loadedModule.ExportedAliases.GetEnumerator().Where{
+                            Write-Host -Object "`t Loading $($_.Key)..." -ForegroundColor DarkGray
+
+                            # Using -like to support wildcard.
                             $_.Key -like $TaskToExport
                         }.ForEach{
-                            # Dot sourcing the Tasks via their exported aliases
+                            # Dot-sourcing the Tasks via their exported aliases.
                             . (Get-Alias $_.Key)
                         }
                     }
                 }
                 catch
                 {
-                    Write-Host -ForegroundColor Red -Object "Could not load tasks for module $Module."
-                    Write-Error $_
+                    Write-Host -Object "Could not load tasks for module $module." -ForegroundColor Red
+
+                    Write-Error -Message $_
                 }
             }
         }
 
-        # Loading Build Tasks defined in the .build/ folder (will override the ones imported above if same task name)
-        Get-ChildItem -Path ".build/" -Recurse -Include *.ps1 -ErrorAction Ignore | ForEach-Object {
-            "Importing file $($_.BaseName)" | Write-Verbose
-            . $_.FullName
-        }
+        # Loading Build Tasks defined in the .build/ folder (will override the ones imported above if same task name).
+        Get-ChildItem -Path '.build/' -Recurse -Include '*.ps1' -ErrorAction Ignore |
+            ForEach-Object {
+                "Importing file $($_.BaseName)" | Write-Verbose
 
-        # Synopsis: Empty task, useful to test the bootstrap process
+                . $_.FullName
+            }
+
+        # Synopsis: Empty task, useful to test the bootstrap process.
         task noop { }
 
-        # Define default task sequence ("."), can be overridden in the $BuildInfo
+        # Define default task sequence ("."), can be overridden in the $BuildInfo.
         task . {
-            Write-Build Yellow "No sequence currently defined for the default task"
+            Write-Build -Object 'No sequence currently defined for the default task' -ForegroundColor Yellow
         }
 
-        # Load Invoke-Build task sequences/workflows from $BuildInfo
-        Write-Host -ForegroundColor DarkGray "Adding Workflow from configuration:"
-        foreach ($Workflow in $BuildInfo.BuildWorkflow.keys)
+        Write-Host -Object 'Adding Workflow from configuration:' -ForegroundColor DarkGray
+
+        # Load Invoke-Build task sequences/workflows from $BuildInfo.
+        foreach ($workflow in $BuildInfo.BuildWorkflow.keys)
         {
-            Write-Verbose "Creating Build Workflow '$Workflow' with tasks $($BuildInfo.BuildWorkflow.($Workflow) -join ', ')"
-            $WorkflowItem = $BuildInfo.BuildWorkflow.($Workflow)
-            if ($WorkflowItem.Trim() -match '^\{(?<sb>[\w\W]*)\}$')
+            Write-Verbose -Message "Creating Build Workflow '$Workflow' with tasks $($BuildInfo.BuildWorkflow.($Workflow) -join ', ')."
+
+            $workflowItem = $BuildInfo.BuildWorkflow.($workflow)
+
+            if ($workflowItem.Trim() -match '^\{(?<sb>[\w\W]*)\}$')
             {
-                $WorkflowItem = [ScriptBlock]::Create($Matches['sb'])
+                $workflowItem = [ScriptBlock]::Create($Matches['sb'])
             }
-            Write-Host -ForegroundColor DarkGray "  +-> $Workflow"
-            task $Workflow $WorkflowItem
+
+            Write-Host -Object "  +-> $workflow" -ForegroundColor DarkGray
+
+            task $workflow $workflowItem
         }
 
-        Write-Host -ForeGroundColor magenta "[build] Executing requested workflow: $($Tasks -join ', ')"
+        Write-Host -Object "[build] Executing requested workflow: $($Tasks -join ', ')" -ForeGroundColor Magenta
 
     }
     finally
     {
-        Pop-Location -StackName BeforeBuild
+        Pop-Location -StackName 'BeforeBuild'
     }
 }
 
 Begin
 {
+    # Find build config if not specified.
+    if (-not $BuildConfig)
+    {
+        $config = Get-ChildItem -Path "$PSScriptRoot\*" -Include 'build.y*ml', 'build.psd1', 'build.json*' -ErrorAction Ignore
+
+        if (-not $config -or ($config -is [System.Array] -and $config.Length -le 0))
+        {
+            throw 'No build configuration found. Specify path via parameter BuildConfig.'
+        }
+        elseif ($config -is [System.Array])
+        {
+            if ($config.Length -gt 1)
+            {
+                throw 'More than one build configuration found. Specify which path to use via parameter BuildConfig.'
+            }
+
+            $BuildConfig = $config[0]
+        }
+        else
+        {
+            $BuildConfig = $config
+        }
+    }
+
     # Bootstrapping the environment before using Invoke-Build as task runner
 
-    if ($MyInvocation.ScriptName -notLike '*Invoke-Build.ps1')
+    if ($MyInvocation.ScriptName -notlike '*Invoke-Build.ps1')
     {
-        Write-Host -foregroundColor Green "[pre-build] Starting Build Init"
-        Push-Location $PSScriptRoot -StackName BuildModule
+        Write-Host -Object "[pre-build] Starting Build Init" -ForegroundColor Green
+
+        Push-Location $PSScriptRoot -StackName 'BuildModule'
     }
 
     if ($RequiredModulesDirectory -in @('CurrentUser', 'AllUsers'))
     {
-        # Installing modules instead of saving them
-        Write-Host -foregroundColor Green "[pre-build] Required Modules will be installed for $RequiredModulesDirectory, not saved."
-        # Tell Resolve-Dependency to use provided scope as the -PSDependTarget if not overridden in Build.psd1
+        # Installing modules instead of saving them.
+        Write-Host -Object "[pre-build] Required Modules will be installed to the PowerShell module path that is used for $RequiredModulesDirectory." -ForegroundColor Green
+
+        <#
+            The variable $PSDependTarget will be used below when building the splatting
+            variable before calling Resolve-Dependency.ps1, unless overridden in the
+            file Resolve-Dependency.psd1.
+        #>
         $PSDependTarget = $RequiredModulesDirectory
     }
     else
     {
-        if (-Not (Split-Path -IsAbsolute -Path $OutputDirectory))
+        if (-not (Split-Path -IsAbsolute -Path $OutputDirectory))
         {
             $OutputDirectory = Join-Path -Path $PSScriptRoot -ChildPath $OutputDirectory
         }
 
-        # Resolving the absolute path to save the required modules to
-        if (-Not (Split-Path -IsAbsolute -Path $RequiredModulesDirectory))
+        # Resolving the absolute path to save the required modules to.
+        if (-not (Split-Path -IsAbsolute -Path $RequiredModulesDirectory))
         {
             $RequiredModulesDirectory = Join-Path -Path $PSScriptRoot -ChildPath $RequiredModulesDirectory
         }
 
-        # Create the output/modules folder if not exists, or resolve the Absolute path otherwise
-        if (Resolve-Path $RequiredModulesDirectory -ErrorAction SilentlyContinue)
+        # Create the output/modules folder if not exists, or resolve the Absolute path otherwise.
+        if (Resolve-Path -Path $RequiredModulesDirectory -ErrorAction SilentlyContinue)
         {
-            Write-Debug "[pre-build] Required Modules path already exist at $RequiredModulesDirectory"
-            $RequiredModulesPath = Convert-Path $RequiredModulesDirectory
+            Write-Debug -Message "[pre-build] Required Modules path already exist at $RequiredModulesDirectory"
+
+            $requiredModulesPath = Convert-Path -Path $RequiredModulesDirectory
         }
         else
         {
-            Write-Host -foregroundColor Green "[pre-build] Creating required modules directory $RequiredModulesDirectory."
-            $RequiredModulesPath = (New-Item -ItemType Directory -Force -Path $RequiredModulesDirectory).FullName
+            Write-Host -Object "[pre-build] Creating required modules directory $RequiredModulesDirectory." -ForegroundColor Green
+
+            $requiredModulesPath = (New-Item -ItemType Directory -Force -Path $RequiredModulesDirectory).FullName
         }
 
-        # Prepending $RequiredModulesPath folder to PSModulePath to resolve from this folder FIRST
-        if ($RequiredModulesDirectory -notIn @('CurrentUser', 'AllUsers') -and
-            (($Env:PSModulePath -split [io.path]::PathSeparator) -notContains $RequiredModulesDirectory))
+        $powerShellModulePaths = $env:PSModulePath -split [System.IO.Path]::PathSeparator
+
+        # Pre-pending $requiredModulesPath folder to PSModulePath to resolve from this folder FIRST.
+        if ($RequiredModulesDirectory -notin @('CurrentUser', 'AllUsers') -and
+            ($powerShellModulePaths -notcontains $RequiredModulesDirectory))
         {
-            Write-Host -foregroundColor Green "[pre-build] Prepending '$RequiredModulesDirectory' folder to PSModulePath"
-            $Env:PSModulePath = $RequiredModulesDirectory + [io.path]::PathSeparator + $Env:PSModulePath
+            Write-Host -Object "[pre-build] Pre-pending '$RequiredModulesDirectory' folder to PSModulePath" -ForegroundColor Green
+
+            $env:PSModulePath = $RequiredModulesDirectory + [System.IO.Path]::PathSeparator + $env:PSModulePath
         }
 
-        # Checking if the user should -ResolveDependency
-        if ((!(Get-Module -ListAvailable powershell-yaml) -or !(Get-Module -ListAvailable InvokeBuild) -or !(Get-Module -ListAvailable PSDepend)) -and !$ResolveDependency)
+        $powerShellYamlModule = Get-Module -Name 'powershell-yaml' -ListAvailable
+        $invokeBuildModule = Get-Module -Name 'InvokeBuild' -ListAvailable
+        $psDependModule = Get-Module -Name 'PSDepend' -ListAvailable
+
+        # Checking if the user should -ResolveDependency.
+        if (-not ($powerShellYamlModule -and $invokeBuildModule -and $psDependModule) -and -not $ResolveDependency)
         {
-            if ($AutoRestore -or !$PSBoundParameters.ContainsKey('Tasks') -or $Tasks -contains 'build')
+            if ($AutoRestore -or -not $PSBoundParameters.ContainsKey('Tasks') -or $Tasks -contains 'build')
             {
-                Write-Host -ForegroundColor Yellow "[pre-build] Dependency missing, running './build.ps1 -ResolveDependency -Tasks noop' for you `r`n"
+                Write-Host -Object "[pre-build] Dependency missing, running './build.ps1 -ResolveDependency -Tasks noop' for you `r`n" -ForegroundColor Yellow
+
                 $ResolveDependency = $true
             }
             else
             {
-                Write-Warning "Some required Modules are missing, make sure you first run with the '-ResolveDependency' parameter."
-                Write-Warning "Running 'build.ps1 -ResolveDependency -Tasks noop' will pull required modules without running the build task."
+                Write-Warning -Message "Some required Modules are missing, make sure you first run with the '-ResolveDependency' parameter. Running 'build.ps1 -ResolveDependency -Tasks noop' will pull required modules without running the build task."
             }
         }
 
         if ($BuiltModuleSubdirectory)
         {
-            if (-Not (Split-Path -IsAbsolute $BuiltModuleSubdirectory))
+            if (-not (Split-Path -IsAbsolute -Path $BuiltModuleSubdirectory))
             {
-                $BuildModuleOutput = Join-Path $OutputDirectory $BuiltModuleSubdirectory
+                $BuildModuleOutput = Join-Path -Path $OutputDirectory -ChildPath $BuiltModuleSubdirectory
             }
             else
             {
@@ -289,65 +424,82 @@ Begin
             $BuildModuleOutput = $OutputDirectory
         }
 
-        # Prepending $BuildModuleOutput folder to PSModulePath to resolve built module from this folder
-        if (($Env:PSModulePath -split [io.path]::PathSeparator) -notContains $BuildModuleOutput)
+        # Pre-pending $BuildModuleOutput folder to PSModulePath to resolve built module from this folder.
+        if ($powerShellModulePaths -notcontains $BuildModuleOutput)
         {
-            Write-Host -foregroundColor Green "[pre-build] Prepending '$BuildModuleOutput' folder to PSModulePath"
-            $Env:PSModulePath = $BuildModuleOutput + [io.path]::PathSeparator + $Env:PSModulePath
+            Write-Host -Object "[pre-build] Pre-pending '$BuildModuleOutput' folder to PSModulePath" -ForegroundColor Green
+
+            $env:PSModulePath = $BuildModuleOutput + [System.IO.Path]::PathSeparator + $env:PSModulePath
         }
 
-        # Tell Resolve-Dependency to use $RequiredModulesPath as -PSDependTarget if not overridden in Build.psd1
-        $PSDependTarget = $RequiredModulesPath
+        <#
+            The variable $PSDependTarget will be used below when building the splatting
+            variable before calling Resolve-Dependency.ps1, unless overridden in the
+            file Resolve-Dependency.psd1.
+        #>
+        $PSDependTarget = $requiredModulesPath
     }
 
     if ($ResolveDependency)
     {
-        Write-Host -Object "[pre-build] Resolving dependencies." -foregroundColor Green
-        $ResolveDependencyParams = @{ }
+        Write-Host -Object "[pre-build] Resolving dependencies." -ForegroundColor Green
+        $resolveDependencyParams = @{ }
 
-        # If BuildConfig is a Yaml file, bootstrap powershell-yaml via ResolveDependency
+        # If BuildConfig is a Yaml file, bootstrap powershell-yaml via ResolveDependency.
         if ($BuildConfig -match '\.[yaml|yml]$')
         {
-            $ResolveDependencyParams.add('WithYaml', $True)
+            $resolveDependencyParams.Add('WithYaml', $true)
         }
 
-        $ResolveDependencyAvailableParams = (Get-Command -Name '.\Resolve-Dependency.ps1').parameters.keys
-        foreach ($CmdParameter in $ResolveDependencyAvailableParams)
-        {
+        $resolveDependencyAvailableParams = (Get-Command -Name '.\Resolve-Dependency.ps1').Parameters.Keys
 
+        foreach ($cmdParameter in $resolveDependencyAvailableParams)
+        {
             # The parameter has been explicitly used for calling the .build.ps1
-            if ($MyInvocation.BoundParameters.ContainsKey($CmdParameter))
+            if ($MyInvocation.BoundParameters.ContainsKey($cmdParameter))
             {
-                $ParamValue = $MyInvocation.BoundParameters.ContainsKey($CmdParameter)
-                Write-Debug " adding  $CmdParameter :: $ParamValue [from user-provided parameters to Build.ps1]"
-                $ResolveDependencyParams.Add($CmdParameter, $ParamValue)
+                $paramValue = $MyInvocation.BoundParameters.ContainsKey($cmdParameter)
+
+                Write-Debug " adding  $cmdParameter :: $paramValue [from user-provided parameters to Build.ps1]"
+
+                $resolveDependencyParams.Add($cmdParameter, $paramValue)
             }
             # Use defaults parameter value from Build.ps1, if any
             else
             {
-                if ($ParamValue = Get-Variable -Name $CmdParameter -ValueOnly -ErrorAction Ignore)
+                $paramValue = Get-Variable -Name $cmdParameter -ValueOnly -ErrorAction Ignore
+
+                if ($paramValue)
                 {
-                    Write-Debug " adding  $CmdParameter :: $ParamValue [from default Build.ps1 variable]"
-                    $ResolveDependencyParams.add($CmdParameter, $ParamValue)
+                    Write-Debug " adding  $cmdParameter :: $paramValue [from default Build.ps1 variable]"
+
+                    $resolveDependencyParams.Add($cmdParameter, $paramValue)
                 }
             }
         }
 
-        Write-Host -foregroundColor Green "[pre-build] Starting bootstrap process."
-        .\Resolve-Dependency.ps1 @ResolveDependencyParams
+        Write-Host -Object "[pre-build] Starting bootstrap process." -ForegroundColor Green
+
+        .\Resolve-Dependency.ps1 @resolveDependencyParams
     }
 
-    if ($MyInvocation.ScriptName -notLike '*Invoke-Build.ps1')
+    if ($MyInvocation.ScriptName -notlike '*Invoke-Build.ps1')
     {
-        Write-Verbose "Bootstrap completed. Handing back to InvokeBuild."
+        Write-Verbose -Message "Bootstrap completed. Handing back to InvokeBuild."
+
         if ($PSBoundParameters.ContainsKey('ResolveDependency'))
         {
-            Write-Verbose "Dependency already resolved. Removing task"
+            Write-Verbose -Message "Dependency already resolved. Removing task."
+
             $null = $PSBoundParameters.Remove('ResolveDependency')
         }
-        Write-Host -foregroundColor Green "[build] Starting build with InvokeBuild."
+
+        Write-Host -Object "[build] Starting build with InvokeBuild." -ForegroundColor Green
+
         Invoke-Build @PSBoundParameters -Task $Tasks -File $MyInvocation.MyCommand.Path
-        Pop-Location -StackName BuildModule
+
+        Pop-Location -StackName 'BuildModule'
+
         return
     }
 }

--- a/build.yaml
+++ b/build.yaml
@@ -63,11 +63,9 @@ BuildWorkflow:
         param
         (
             $OutputDirectory = (property OutputDirectory (Join-Path $BuildRoot 'output')),
-            $ProjectName = (property ProjectName ''),
+            $ProjectName = (property ProjectName $(Get-SamplerProjectName -BuildRoot $BuildRoot)),
             $BuildInfo = (property BuildInfo @{ })
         )
-
-        $ProjectName = Get-ProjectName -BuildRoot $BuildRoot
 
         $pathToModuleManifest = Resolve-Path -Path "$OutputDirectory/$ProjectName/**/$ProjectName.psd1"
         $existingAliases = @((Test-ModuleManifest -Path $pathToModuleManifest).ExportedAliases.Values.Name)

--- a/source/Public/Wait-ForIdleLcm.ps1
+++ b/source/Public/Wait-ForIdleLcm.ps1
@@ -1,6 +1,6 @@
 <#
     .SYNOPSIS
-        Waits for LCM to become idle.
+        Waits for LCM to return from busy state.
 
     .PARAMETER Clear
         If specified, the LCM will also be cleared of DSC configurations.
@@ -13,6 +13,9 @@
     .NOTES
         Used in integration test where integration tests run to quickly before
         LCM have time to cool down.
+
+        It will return if the LCM state is other than 'Busy'. The other states are
+        'Idle', 'PendingConfiguration', or 'PendingReboot'.
 #>
 function Wait-ForIdleLcm
 {

--- a/source/Public/Wait-ForIdleLcm.ps1
+++ b/source/Public/Wait-ForIdleLcm.ps1
@@ -5,6 +5,11 @@
     .PARAMETER Clear
         If specified, the LCM will also be cleared of DSC configurations.
 
+    .PARAMETER Timeout
+        Specifies the timeout in seconds when the command returns regardless of
+        state. If not specified it waits indefinitely for LCM to change `LCMState`
+        from 'Busy'.
+
     .NOTES
         Used in integration test where integration tests run to quickly before
         LCM have time to cool down.
@@ -16,14 +21,43 @@ function Wait-ForIdleLcm
     (
         [Parameter()]
         [System.Management.Automation.SwitchParameter]
-        $Clear
+        $Clear,
+
+        [Parameter()]
+        [System.UInt32]
+        $Timeout
     )
 
-    while ((Get-DscLocalConfigurationManager).LCMState -ne 'Idle')
+    $timer = $null
+
+    if ($PSBoundParameters.ContainsKey('Timeout'))
+    {
+        $timer = [System.Diagnostics.Stopwatch]::StartNew()
+    }
+
+    <#
+        When LCM is:
+
+        Running - LCMState is set to 'Busy'
+        Successful - LCMState is set to 'Idle' (eventually)
+        Failed - LCMState is set to 'PendingConfiguration'
+        Requires restart - LCMState is set to 'PendingReboot'
+    #>
+    while ((Get-DscLocalConfigurationManager).LCMState -eq 'Busy')
     {
         Write-Verbose -Message 'Waiting for the LCM to become idle'
 
+        if ($timer -and $timer.Elapsed.Seconds -ge $Timeout)
+        {
+            break
+        }
+
         Start-Sleep -Seconds 2
+    }
+
+    if ($timer)
+    {
+        $timer.Stop()
     }
 
     if ($Clear)

--- a/source/Public/Wait-ForIdleLcm.ps1
+++ b/source/Public/Wait-ForIdleLcm.ps1
@@ -24,7 +24,7 @@ function Wait-ForIdleLcm
         $Clear,
 
         [Parameter()]
-        [System.UInt32]
+        [System.TimeSpan]
         $Timeout
     )
 
@@ -47,7 +47,7 @@ function Wait-ForIdleLcm
     {
         Write-Verbose -Message 'Waiting for the LCM to become idle'
 
-        if ($timer -and $timer.Elapsed.Seconds -ge $Timeout)
+        if ($timer -and $timer.Elapsed -ge $Timeout)
         {
             break
         }

--- a/source/tasks/Fail_Build_If_HQRM_Tests_Failed.build.ps1
+++ b/source/tasks/Fail_Build_If_HQRM_Tests_Failed.build.ps1
@@ -33,7 +33,7 @@ param
 
     [Parameter()]
     [System.String]
-    $ProjectName = (property ProjectName ''),
+    $ProjectName = (property ProjectName $(Get-SamplerProjectName -BuildRoot $BuildRoot)),
 
     [Parameter()]
     [System.String]
@@ -48,11 +48,6 @@ param
 # Synopsis: This task ensures the build job fails if the test aren't successful.
 task Fail_Build_If_HQRM_Tests_Failed {
     "Asserting that no test failed."
-
-    if ([System.String]::IsNullOrEmpty($ProjectName))
-    {
-        $ProjectName = Get-ProjectName -BuildRoot $BuildRoot
-    }
 
     if (-not (Split-Path -IsAbsolute $OutputDirectory))
     {

--- a/source/tasks/Fail_Build_If_HQRM_Tests_Failed.build.ps1
+++ b/source/tasks/Fail_Build_If_HQRM_Tests_Failed.build.ps1
@@ -33,6 +33,14 @@ param
 
     [Parameter()]
     [System.String]
+    $BuiltModuleSubdirectory = (property BuiltModuleSubdirectory ''),
+
+    [Parameter()]
+    [System.Management.Automation.SwitchParameter]
+    $VersionedOutputDirectory = (property VersionedOutputDirectory $true),
+
+    [Parameter()]
+    [System.String]
     $ProjectName = (property ProjectName $(Get-SamplerProjectName -BuildRoot $BuildRoot)),
 
     [Parameter()]
@@ -49,12 +57,56 @@ param
 task Fail_Build_If_HQRM_Tests_Failed {
     "Asserting that no test failed."
 
-    if (-not (Split-Path -IsAbsolute $OutputDirectory))
-    {
-        $OutputDirectory = Join-Path -Path $ProjectPath -ChildPath $OutputDirectory
+    $OutputDirectory = Get-SamplerAbsolutePath -Path $OutputDirectory -RelativeTo $BuildRoot
 
-        Write-Build -Color 'Yellow' -Text "Absolute path to Output Directory is $OutputDirectory"
+    "`tOutputDirectory       = '$OutputDirectory'"
+
+    $BuiltModuleSubdirectory = Get-SamplerAbsolutePath -Path $BuiltModuleSubdirectory -RelativeTo $OutputDirectory
+
+    if ($VersionedOutputDirectory)
+    {
+        # VersionedOutputDirectory is not [bool]'' nor $false nor [bool]$null
+        # Assume true, wherever it was set
+        $VersionedOutputDirectory = $true
     }
+    else
+    {
+        # VersionedOutputDirectory may be [bool]'' but we can't tell where it's
+        # coming from, so assume the build info (Build.yaml) is right
+        $VersionedOutputDirectory = $BuildInfo['VersionedOutputDirectory']
+    }
+
+    $GetBuiltModuleManifestParams = @{
+        OutputDirectory          = $OutputDirectory
+        BuiltModuleSubdirectory  = $BuiltModuleSubDirectory
+        ModuleName               = $ProjectName
+        VersionedOutputDirectory = $VersionedOutputDirectory
+        ErrorAction              = 'Stop'
+    }
+
+    $builtModuleManifest = Get-SamplerBuiltModuleManifest @GetBuiltModuleManifestParams
+    $builtModuleManifest = [string](Get-Item -Path $builtModuleManifest).FullName
+
+    "`tBuilt Module Manifest = '$builtModuleManifest'"
+
+    $builtModuleBase = Get-SamplerBuiltModuleBase @GetBuiltModuleManifestParams
+    $builtModuleBase = [string](Get-Item -Path $builtModuleBase).FullName
+
+    "`tBuilt Module Base     = '$builtModuleBase'"
+
+    $moduleVersion = Get-BuiltModuleVersion @GetBuiltModuleManifestParams
+
+    $moduleVersionObject = Split-ModuleVersion -ModuleVersion $moduleVersion
+    $moduleVersionFolder = $moduleVersionObject.Version
+    $preReleaseTag       = $moduleVersionObject.PreReleaseString
+
+    "`tModule Version        = '$ModuleVersion'"
+    "`tModule Version Folder = '$moduleVersionFolder'"
+    "`tPre-release Tag       = '$preReleaseTag'"
+
+    "`tProject Path          = $ProjectPath"
+    "`tProject Name          = $ProjectName"
+    "`tBuilt Module Base     = $builtModuleBase"
 
     if (-not (Split-Path -IsAbsolute $DscTestOutputFolder))
     {
@@ -74,23 +126,13 @@ task Fail_Build_If_HQRM_Tests_Failed {
         'Linux'
     }
 
-    $getModuleVersionParameters = @{
-        OutputDirectory = $OutputDirectory
-        ProjectName     = $ProjectName
-    }
-
-    $ModuleVersion = Get-BuiltModuleVersion @getModuleVersionParameters
-
     $psVersion = 'PSv.{0}' -f $PSVersionTable.PSVersion
     $DscTestOutputFileFileName = "DscTest_{0}_v{1}.{2}.{3}.xml" -f $ProjectName, $ModuleVersion, $os, $psVersion
     $DscTestResultObjectClixml = Join-Path -Path $DscTestOutputFolder -ChildPath "DscTestObject_$DscTestOutputFileFileName"
 
     "`t"
-    "`tProject Path        = $ProjectPath"
-    "`tProject Name        = $ProjectName"
-    "`tOutput Directory    = $OutputDirectory"
-    "`tTest Output Folder  = $DscTestOutputFolder"
-    "`tTest Output Object  = $DscTestResultObjectClixml"
+    "`tTest Output Folder    = $DscTestOutputFolder"
+    "`tTest Output Object    = $DscTestResultObjectClixml"
     "`t"
 
     if (-not (Test-Path -Path $DscTestResultObjectClixml))

--- a/source/tasks/Invoke_HQRM_Tests.build.ps1
+++ b/source/tasks/Invoke_HQRM_Tests.build.ps1
@@ -36,11 +36,19 @@ param
 
     [Parameter()]
     [System.String]
+    $BuiltModuleSubdirectory = (property BuiltModuleSubdirectory ''),
+
+    [Parameter()]
+    [System.Management.Automation.SwitchParameter]
+    $VersionedOutputDirectory = (property VersionedOutputDirectory $true),
+
+    [Parameter()]
+    [System.String]
     $ProjectName = (property ProjectName $(Get-SamplerProjectName -BuildRoot $BuildRoot)),
 
     [Parameter()]
     [System.String]
-    $SourcePath = (property SourcePath ''),
+    $SourcePath = (property SourcePath $(Get-SamplerSourcePath -BuildRoot $BuildRoot)),
 
     [Parameter()]
     [System.String]
@@ -74,17 +82,57 @@ param
 
 # Synopsis: Making sure the Module meets some quality standard (help, tests)
 task Invoke_HQRM_Tests {
-    if ([System.String]::IsNullOrEmpty($SourcePath))
+    $OutputDirectory = Get-SamplerAbsolutePath -Path $OutputDirectory -RelativeTo $BuildRoot
+
+    "`tOutputDirectory       = '$OutputDirectory'"
+
+    $BuiltModuleSubdirectory = Get-SamplerAbsolutePath -Path $BuiltModuleSubdirectory -RelativeTo $OutputDirectory
+
+    if ($VersionedOutputDirectory)
     {
-        $SourcePath = Get-SourcePath -BuildRoot $BuildRoot
+        # VersionedOutputDirectory is not [bool]'' nor $false nor [bool]$null
+        # Assume true, wherever it was set
+        $VersionedOutputDirectory = $true
+    }
+    else
+    {
+        # VersionedOutputDirectory may be [bool]'' but we can't tell where it's
+        # coming from, so assume the build info (Build.yaml) is right
+        $VersionedOutputDirectory = $BuildInfo['VersionedOutputDirectory']
     }
 
-    if (-not (Split-Path -IsAbsolute $OutputDirectory))
-    {
-        $OutputDirectory = Join-Path -Path $ProjectPath -ChildPath $OutputDirectory
-
-        Write-Build Yellow "Absolute path to Output Directory is $OutputDirectory"
+    $GetBuiltModuleManifestParams = @{
+        OutputDirectory          = $OutputDirectory
+        BuiltModuleSubdirectory  = $BuiltModuleSubDirectory
+        ModuleName               = $ProjectName
+        VersionedOutputDirectory = $VersionedOutputDirectory
+        ErrorAction              = 'Stop'
     }
+
+    $builtModuleManifest = Get-SamplerBuiltModuleManifest @GetBuiltModuleManifestParams
+    $builtModuleManifest = [string](Get-Item -Path $builtModuleManifest).FullName
+
+    "`tBuilt Module Manifest = '$builtModuleManifest'"
+
+    $builtModuleBase = Get-SamplerBuiltModuleBase @GetBuiltModuleManifestParams
+    $builtModuleBase = [string](Get-Item -Path $builtModuleBase).FullName
+
+    "`tBuilt Module Base     = '$builtModuleBase'"
+
+    $moduleVersion = Get-BuiltModuleVersion @GetBuiltModuleManifestParams
+
+    $moduleVersionObject = Split-ModuleVersion -ModuleVersion $moduleVersion
+    $moduleVersionFolder = $moduleVersionObject.Version
+    $preReleaseTag       = $moduleVersionObject.PreReleaseString
+
+    "`tModule Version        = '$ModuleVersion'"
+    "`tModule Version Folder = '$moduleVersionFolder'"
+    "`tPre-release Tag       = '$preReleaseTag'"
+
+    "`tProject Path          = $ProjectPath"
+    "`tProject Name          = $ProjectName"
+    "`tSource Path           = $SourcePath"
+    "`tBuilt Module Base     = $builtModuleBase"
 
     if (-not (Split-Path -IsAbsolute $DscTestOutputFolder))
     {
@@ -95,8 +143,6 @@ task Invoke_HQRM_Tests {
         OutputDirectory = $OutputDirectory
         ProjectName     = $ProjectName
     }
-
-    $ModuleVersion = Get-BuiltModuleVersion @getModuleVersionParameters
 
     if (-not (Test-Path -Path $DscTestOutputFolder))
     {
@@ -346,13 +392,8 @@ task Invoke_HQRM_Tests {
         }
     }
 
-    "`tProject Path        = $ProjectPath"
-    "`tProject Name        = $ProjectName"
-    "`tSource Path         = $SourcePath"
-    "`tOutput Directory    = $OutputDirectory"
-    "`tBuild Module Output = $BuildModuleOutput"
-    "`tModule Version      = $ModuleVersion"
-    "`tTest Output Folder  = $DscTestOutputFolder"
+    "`tBuild Module Output   = $BuildModuleOutput"
+    "`tTest Output Folder    = $DscTestOutputFolder"
     "`t"
 
     $pesterParameters = @{}

--- a/source/tasks/Invoke_HQRM_Tests.build.ps1
+++ b/source/tasks/Invoke_HQRM_Tests.build.ps1
@@ -36,7 +36,7 @@ param
 
     [Parameter()]
     [System.String]
-    $ProjectName = (property ProjectName ''),
+    $ProjectName = (property ProjectName $(Get-SamplerProjectName -BuildRoot $BuildRoot)),
 
     [Parameter()]
     [System.String]
@@ -74,11 +74,6 @@ param
 
 # Synopsis: Making sure the Module meets some quality standard (help, tests)
 task Invoke_HQRM_Tests {
-    if ([System.String]::IsNullOrEmpty($ProjectName))
-    {
-        $ProjectName = Get-ProjectName -BuildRoot $BuildRoot
-    }
-
     if ([System.String]::IsNullOrEmpty($SourcePath))
     {
         $SourcePath = Get-SourcePath -BuildRoot $BuildRoot

--- a/tests/Unit/Public/Wait-ForIdelLcm.Tests.ps1
+++ b/tests/Unit/Public/Wait-ForIdelLcm.Tests.ps1
@@ -101,7 +101,7 @@ Describe 'Wait-ForIdleLcm' -Tag 'WaitForIdleLcm' {
         }
 
         It 'Should not throw and call the expected mocks' {
-            { Wait-ForIdleLcm -Timeout 8 } | Should -Not -Throw
+            { Wait-ForIdleLcm -Timeout '00:00:08' } | Should -Not -Throw
 
             Assert-MockCalled -CommandName Get-DscLocalConfigurationManager -Times 3 -Scope It -ModuleName $ProjectName
         }


### PR DESCRIPTION
### Added

- `Wait-ForIdleLcm`
  - Added new parameter `Timeout` to be able to return after the specified
    number of seconds (issue #101).

### Changed

- DscResource.Test
  - Updated pipeline files.
- `Wait-ForIdleLcm`
  - Updated to wait as long as the `LCMState` property has the state `'Busy'` (issue #101).
    This will prevent the pipeline to loop indefinitely when an integration
    test fails and the property `LCMState` is set to `PendingConfiguration`.

### Fixed

- `Invoke_HQRM_Tests`
  - Fixed the task so it runs together with latest PowerShell module Sampler.
- `Fail_Build_If_HQRM_Tests_Failed`
  - Fixed the task so it runs together with latest PowerShell module Sampler.

- Fixes #101 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/dscresource.test/107)
<!-- Reviewable:end -->
