### PR TITLE
Fix issue with Pester 5.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Refactoring all tasks to initialise variable with `Set-SamplerTaskVariable` script ([issue #110](https://github.com/dsccommunity/DscResource.Test/issues/110)).
+- Now the data for the Pester containers are cloned to not hit the issue
+  [Using same data with two or more containers fail](https://github.com/pester/Pester/issues/2073).
 
 ## [0.15.1] - 2021-03-29
 

--- a/source/tasks/Invoke_HQRM_Tests.build.ps1
+++ b/source/tasks/Invoke_HQRM_Tests.build.ps1
@@ -426,7 +426,7 @@ task Invoke_HQRM_Tests {
 
     foreach ($testScript in $hqrmTestScripts)
     {
-        $pesterContainers += New-PesterContainer -Path $testScript.FullName -Data $pesterData
+        $pesterContainers += New-PesterContainer -Path $testScript.FullName -Data $pesterData.Clone()
     }
 
     if ($BuildInfo.DscTest.Pester.Configuration -and $pesterConfiguration)


### PR DESCRIPTION
- Now the data for the Pester containers are cloned to not hit the issue
  [Using same data with two or more containers fail](https://github.com/pester/Pester/issues/2073).

_Workaround for issue https://github.com/pester/Pester/issues/2073_.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/dscresource.test/113)
<!-- Reviewable:end -->
