### PR TITLE
Add example support for LCM Meta config - Fixes #116

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added support for examples for LCM Meta Configurations to
+  `Test-ConfigurationName` ([issue #116](https://github.com/dsccommunity/DscResource.Test/issues/116)).
+
 ### Changed
 
 - Refactoring all tasks to initialise variable with `Set-SamplerTaskVariable` script ([issue #110](https://github.com/dsccommunity/DscResource.Test/issues/110)).

--- a/source/Private/Test-ConfigurationName.ps1
+++ b/source/Private/Test-ConfigurationName.ps1
@@ -30,7 +30,10 @@ function Test-ConfigurationName
 
     $configurationDefinition = $definitionAst.Find($astFilter, $true)
 
-    $isOfCorrectType = $configurationDefinition.ConfigurationType -eq [System.Management.Automation.Language.ConfigurationType]::Resource
+    $isOfCorrectType = $configurationDefinition.ConfigurationType -in @(
+        [System.Management.Automation.Language.ConfigurationType]::Resource
+        [System.Management.Automation.Language.ConfigurationType]::Meta
+    )
 
     $configurationName = $configurationDefinition.InstanceName.Value
     $hasEqualName = $configurationName -eq $publishFilename

--- a/tests/Unit/Private/Test-ConfigurationName.Tests.ps1
+++ b/tests/Unit/Private/Test-ConfigurationName.Tests.ps1
@@ -42,6 +42,24 @@ InModuleScope $ProjectName {
             }
         }
 
+        Context 'When a script file has the correct name but is a LCM meta configuration' {
+            BeforeAll {
+                $definition = '
+                [DSCLocalConfigurationManager()]
+                Configuration TestConfig
+                {
+                }
+            '
+
+                $definition | Out-File -FilePath $mockScriptPath -Encoding utf8 -Force
+            }
+
+            It 'Should return true' {
+                $result = Test-ConfigurationName -Path $mockScriptPath
+                $result | Should -BeTrue
+            }
+        }
+
         Context 'When a script file has the different name than the configuration name' {
             BeforeAll {
                 $definition = '


### PR DESCRIPTION
This PR adds support for examples containing LCM meta configurations in `Test-ConfigurationName` to support xPSDesiredStateConfiguration.

@gaelcolas, @johlju - can you review when you have time?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/dscresource.test/117)
<!-- Reviewable:end -->
