### PR TITLE
`Restore-TestEnvironment`: New parameter `KeepNewMachinePSModulePath`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `Restore-TestEnvironment`
+  - A new parameter `KeepNewMachinePSModulePath` was added and only works
+    if the test type is `Integration` or `All`. The new parameter will
+    keep any new paths that was added to the machine environment variable
+    `PSModulePath` after the command `Initialize-TestEnvironment` was called.
+    This is helpful if a a path is added by an integration test and is needed
+    by a second integration test and there is a need to run `Restore-TestEnvironment`
+    between tests.
+- Added private function `Join-PSModulePath` that will concatenate two
+  strings with semi-colon separated paths.
+
 ### Fixed
 
 - `Initialize-TestEnvironment`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,24 @@
 # Changelog for DscResource.Test
 
-# Changelog
-
 All notable changes to this project will be documented in this file.
 
 The format is based on and uses the types of changes according to [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Fixed
+
+- `Initialize-TestEnvironment`
+  - Now `$script:machineOldPSModulePath` is always set when called with the
+    test type `Integration` or `All`. Before it reverted to the paths on the
+    event `OnRemove` that were the current paths when `Initialize-TestEnvironment`
+    was first called. On subsequent calls any new paths were ignored.
+  - If there are a subsequent call to `Initialize-TestEnvironment` without the
+    command `Restore-TestEnvironment` was called prior the command will now
+    fail with a non-terminating exception asking the user to run `Restore-TestEnvironment`
+    to avoid the previously saved paths (`$script:machineOldPSModulePath`)
+    to be overwritten.
 
 ## [0.16.1] - 2022-04-20
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -56,8 +56,6 @@ stages:
   - stage: Test
     dependsOn: Build
     jobs:
-
-
       - job: test_windows_wps
         displayName: 'Test Windows (WPS)'
         pool:

--- a/source/Private/Join-PSModulePath.ps1
+++ b/source/Private/Join-PSModulePath.ps1
@@ -1,0 +1,41 @@
+
+<#
+    .SYNOPSIS
+        Concatenates two string that contain semi-colon separated strings.
+
+    .PARAMETER Path
+        A string with all the paths separated by semi-colons.
+
+    .PARAMETER NewPath
+        A string with all the paths separated by semi-colons.
+
+    .EXAMPLE
+        Join-PSModulePath -Path '<Path 1>;<Path 2>' -NewPath 'Path3;Path4'
+#>
+function Join-PSModulePath
+{
+    [CmdletBinding()]
+    [OutputType([System.String])]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [System.String]
+        $Path,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [System.String]
+        $NewPath
+    )
+
+    foreach ($currentNewPath in ($NewPath -split ';'))
+    {
+        if ($Path -cnotmatch [System.Text.RegularExpressions.Regex]::Escape($currentNewPath))
+        {
+            $Path = @($Path, $currentNewPath) -join ';'
+        }
+    }
+
+    return $Path
+}

--- a/source/Public/Initialize-TestEnvironment.ps1
+++ b/source/Public/Initialize-TestEnvironment.ps1
@@ -223,6 +223,7 @@ function Initialize-TestEnvironment
             {
                 Write-Error -Message 'There were already saved paths of the machine environment variable PSModulePath from a previous call to the command. The previous saved paths will be overwritten if ErrorAction is not set to Stop. To avoid this error run the command Restore-TestEnvironment before subsequent calls of the command Initialize-TestEnvironment' -Category 'InvalidData' -ErrorId 'IT0001' -TargetObject 'PSModulePath'
             }
+
             # Preserve and set the execution policy so that the DSC MOF can be created
             $currentMachineExecutionPolicy = Get-ExecutionPolicy -Scope 'LocalMachine'
             if ($PSBoundParameters.ContainsKey('MachineExecutionPolicy'))

--- a/source/Public/Initialize-TestEnvironment.ps1
+++ b/source/Public/Initialize-TestEnvironment.ps1
@@ -219,12 +219,10 @@ function Initialize-TestEnvironment
             $Principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
         )
         {
-            if (!$script:MachineOldPSModulePath)
+            if ($script:MachineOldPSModulePath)
             {
-                Write-Warning "This will change your Machine Environment Variable"
-                $script:MachineOldPSModulePath = [System.Environment]::GetEnvironmentVariable('PSModulePath', 'Machine')
+                Write-Error -Message 'There were already saved paths of the machine environment variable PSModulePath from a previous call to the command. The previous saved paths will be overwritten if ErrorAction is not set to Stop. To avoid this error run the command Restore-TestEnvironment before subsequent calls of the command Initialize-TestEnvironment' -Category 'InvalidData' -ErrorId 'IT0001' -TargetObject 'PSModulePath'
             }
-
             # Preserve and set the execution policy so that the DSC MOF can be created
             $currentMachineExecutionPolicy = Get-ExecutionPolicy -Scope 'LocalMachine'
             if ($PSBoundParameters.ContainsKey('MachineExecutionPolicy'))
@@ -254,6 +252,11 @@ function Initialize-TestEnvironment
             }
 
             Write-Verbose -Message ('The machine execution policy is set to ''{0}''' -f $currentMachineExecutionPolicy)
+
+            Write-Warning -Message 'This will change your machine environment variable PSModulePath but can be restored by running the command Restore-TestEnvironment.'
+
+            # The variable $script:machineOldPSModulePath is also used in suffix.ps1.
+            $script:machineOldPSModulePath = [System.Environment]::GetEnvironmentVariable('PSModulePath', 'Machine')
 
             <#
                 For integration tests we have to set the machine's PSModulePath because otherwise the

--- a/source/Public/Restore-TestEnvironment.ps1
+++ b/source/Public/Restore-TestEnvironment.ps1
@@ -38,12 +38,6 @@ function Restore-TestEnvironment
     if ($TestEnvironment.OldPSModulePath -ne $env:PSModulePath)
     {
         Set-PSModulePath -Path $TestEnvironment.OldPSModulePath
-
-        if ($TestEnvironment.TestType -in ('Integration','All'))
-        {
-            # Restore the machine PSModulePath for integration tests.
-            Set-PSModulePath -Path $TestEnvironment.OldPSModulePath -Machine
-        }
     }
 
     # Restore the Execution Policy
@@ -52,9 +46,15 @@ function Restore-TestEnvironment
         Set-ExecutionPolicy -ExecutionPolicy $TestEnvironment.OldExecutionPolicy -Scope 'Process' -Force
     }
 
-    if ($script:MachineOldPSModulePath)
+    if ($TestEnvironment.TestType -in ('Integration','All') -and $script:MachineOldPSModulePath)
     {
-        [System.Environment]::SetEnvironmentVariable('PSModulePath', $script:MachineOldPSModulePath, 'Machine')
+        <#
+            Restore the machine PSModulePath. The variable $script:machineOldPSModulePath
+            is also used in suffix.ps1.
+        #>
+        Set-PSModulePath -Path $script:MachineOldPSModulePath -Machine -ErrorAction 'Stop'
+
+        $script:MachineOldPSModulePath = $null
     }
 
     if ($script:MachineOldExecutionPolicy)

--- a/source/suffix.ps1
+++ b/source/suffix.ps1
@@ -1,7 +1,9 @@
 $MyInvocation.MyCommand.ScriptBlock.Module.OnRemove = {
-    if ($script:MachineOldPSModulePath)
+    if ($script:machineOldPSModulePath)
     {
-        [System.Environment]::SetEnvironmentVariable('PSModulePath', $script:MachineOldPSModulePath, 'Machine')
+        Set-PSModulePath -Path $script:machineOldPSModulePath -Machine -ErrorAction 'Stop'
+
+        $script:machineOldPSModulePath = $null
     }
 
     if ($script:MachineOldExecutionPolicy)

--- a/tests/Unit/Public/Initialize-TestEnvironment.Tests.ps1
+++ b/tests/Unit/Public/Initialize-TestEnvironment.Tests.ps1
@@ -9,6 +9,17 @@ Import-Module $ProjectName -Force
 
 InModuleScope $ProjectName {
     Describe 'Initialize-TestEnvironment' {
+        BeforeAll {
+            if ($script:machineOldPSModulePath)
+            {
+                throw 'The script variable $script:machineOldPSModulePath was already set, cannot run unit test. This should not happen unless the test is run in the context of an integration test.'
+            }
+        }
+
+        AfterAll {
+            $script:machineOldPSModulePath = $null
+        }
+
         Context 'When initializing the test environment' {
             BeforeAll {
                 $mockDscModuleName = 'TestModule'

--- a/tests/Unit/Public/Initialize-TestEnvironment.Tests.ps1
+++ b/tests/Unit/Public/Initialize-TestEnvironment.Tests.ps1
@@ -113,7 +113,6 @@ InModuleScope $ProjectName {
                     DSCResourceName = $mockDscResourceName
                     TestType        = $TestType
                     ResourceType    = $ResourceType
-                    ErrorAction     = 'SilentlyContinue'
                 }
 
                 { Initialize-TestEnvironment @initializeTestEnvironmentParameters } | Should -Not -Throw

--- a/tests/Unit/Public/Initialize-TestEnvironment.Tests.ps1
+++ b/tests/Unit/Public/Initialize-TestEnvironment.Tests.ps1
@@ -16,7 +16,10 @@ InModuleScope $ProjectName {
             }
         }
 
-        AfterAll {
+        AfterEach {
+            <#
+                Make sure to set this to $null so that the unit tests won't fail.
+            #>
             $script:machineOldPSModulePath = $null
         }
 
@@ -110,6 +113,7 @@ InModuleScope $ProjectName {
                     DSCResourceName = $mockDscResourceName
                     TestType        = $TestType
                     ResourceType    = $ResourceType
+                    ErrorAction     = 'SilentlyContinue'
                 }
 
                 { Initialize-TestEnvironment @initializeTestEnvironmentParameters } | Should -Not -Throw


### PR DESCRIPTION
#### Pull Request (PR) description
- `Restore-TestEnvironment`
  - A new parameter `KeepNewMachinePSModulePath` was added and only works
    if the test type is `Integration` or `All`. The new parameter will
    keep any new paths that was added to the machine environment variable
    `PSModulePath` after the command `Initialize-TestEnvironment` was called.
    This is helpful if a a path is added by an integration test and is needed
    by a second integration test and there is a need to run `Restore-TestEnvironment`
    between tests.
- Added private function `Join-PSModulePath` that will concatenate two
  strings with semi-colon separated paths.
- `Initialize-TestEnvironment`
  - Now `$script:machineOldPSModulePath` is always set when called with the
    test type `Integration` or `All`. Before it reverted to the paths on the
    event `OnRemove` that were the current paths when `Initialize-TestEnvironment`
    was first called. On subsequent calls any new paths were ignored.
  - If there are a subsequent call to `Initialize-TestEnvironment` without the
    command `Restore-TestEnvironment` was called prior the command will now
    fail with a non-terminating exception asking the user to run `Restore-TestEnvironment`
    to avoid the previously saved paths (`$script:machineOldPSModulePath`)
    to be overwritten.

#### This Pull Request (PR) fixes the following issues

- Fixes #127

#### Task list

<!--
    To aid community reviewers in reviewing and merging your PR, please take the time to run
    through the below checklist and make sure your PR has everything updated as required.

    Change to [x] for each task in the task list that applies to your PR. For those task that
    don't apply to you PR, leave those as is.
-->

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Documentation added/updated in README.md.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/DscResource.Test/128)
<!-- Reviewable:end -->
