### PR TITLE
Allowing to skip tests with 'SuppressMessageAttribute'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixes
+
+- Added tag `AllowSuppressMessageAttribute` to test `Should not suppress the required rule` to allow usage of `SuppressMessageAttribute` [#135](https://github.com/dsccommunity/DscResource.Test/issues/135).
+
 ## [0.19.0] - 2026-01-23
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixes
+### Fixed
 
 - Added tag `AllowSuppressMessageAttribute` to test `Should not suppress the required rule` to allow usage of `SuppressMessageAttribute` [#135](https://github.com/dsccommunity/DscResource.Test/issues/135).
 

--- a/README.md
+++ b/README.md
@@ -1174,6 +1174,37 @@ Invoke-Pester -Container $container -Output Detailed
 
 ### PSSAResource.common
 
+This test runs PSScriptAnalyzer against the source files and validates
+compliance with required and custom rules.
+
+#### Skipping tests that validate SuppressMessageAttribute usage
+
+The test `Should not suppress the required rule` validates that no required
+PSSA rules are suppressed using `SuppressMessageAttribute`. If you need to
+suppress a required rule in your module (which is generally not recommended),
+you can exclude this specific test by using the tag `AllowSuppressMessageAttribute`
+with the `ExcludeTagFilter` parameter.
+
+**Example using build.yaml:**
+
+```yaml
+DscTest:
+  Pester:
+    ExcludeTagFilter:
+      - AllowSuppressMessageAttribute
+```
+
+**Example using Invoke-Pester directly:**
+
+```powershell
+$container = New-PesterContainer -Path "$pathToHQRMTests/PSSAResource.common.*.Tests.ps1" -Data @{
+    ProjectPath = '.'
+    ModuleBase = "./output/$dscResourceModuleName/*"
+}
+
+Invoke-Pester -Container $container -ExcludeTagFilter 'AllowSuppressMessageAttribute'
+```
+
 #### Parameters
 
 <!-- markdownlint-disable MD013 - Line length -->

--- a/source/Tests/QA/PSSAResource.common.v5.Tests.ps1
+++ b/source/Tests/QA/PSSAResource.common.v5.Tests.ps1
@@ -166,7 +166,7 @@ Describe 'Common Tests - PS Script Analyzer on Source Files' -Tag @('DscPSSA', '
             }
         }
 
-        It 'Should not suppress the required rule ''<_>''' -ForEach $requiredRuleToTest -Tag @('Common Tests - Required Script Analyzer Rules', 'RequiredPSSA') {
+        It 'Should not suppress the required rule ''<_>''' -ForEach $requiredRuleToTest -Tag @('Common Tests - Required Script Analyzer Rules', 'RequiredPSSA', 'AllowSuppressMessageAttribute') {
             $_ | Should -Not -BeIn $suppressedRuleNames -Because 'no module script file should suppress a required Script Analyzer rule'
         }
 


### PR DESCRIPTION
#### Pull Request (PR) description

Added tag `AllowSuppressMessageAttribute` to test `Should not suppress the required rule` to allow usage of `SuppressMessageAttribute` [#135](https://github.com/dsccommunity/DscResource.Test/issues/135).

#### This Pull Request (PR) fixes the following issues

- Fixes #135

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [x] Documentation added/updated in README.md.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/DscResource.Test/178)
<!-- Reviewable:end -->
