### PR TITLE
Fail the build on failed HQRM blocks and containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `Fail_Build_If_HQRM_Tests_Failed` now fails the build when the Pester run
+  reports failed blocks or failed containers (for example a discovery failure
+  such as an empty `-ForEach`), not only when `FailedCount` is greater than zero.
+  Such container/discovery failures leave `FailedCount` at `0`, so the previous
+  gate let them pass as a green build. The task now gates on the Pester `Result`
+  property, matching the check already used in `Invoke_HQRM_Tests`.
 - Added tag `AllowSuppressMessageAttribute` to test `Should not suppress the required rule` to allow usage of `SuppressMessageAttribute` [#135](https://github.com/dsccommunity/DscResource.Test/issues/135).
 
 ## [0.19.0] - 2026-01-23

--- a/source/tasks/Fail_Build_If_HQRM_Tests_Failed.build.ps1
+++ b/source/tasks/Fail_Build_If_HQRM_Tests_Failed.build.ps1
@@ -97,6 +97,18 @@ task Fail_Build_If_HQRM_Tests_Failed {
     {
         $DscTestObject = Import-Clixml -Path $DscTestResultObjectClixml -ErrorAction 'Stop'
 
-        Assert-Build -Condition ($DscTestObject.FailedCount -eq 0) -Message ('Failed {0} tests. Aborting Build.' -f $DscTestObject.FailedCount)
+        <#
+            A discovery/container failure (for example an empty -ForEach, or a
+            parse error in a test file) does not increase FailedCount. It is
+            reported through FailedContainersCount/FailedBlocksCount and the
+            overall Result. Gating on FailedCount alone therefore lets such
+            failures slip through as a green build. Gate on Result instead, which
+            already accounts for failed tests, blocks and containers. This mirrors
+            the check already used in the Invoke_HQRM_Tests task.
+        #>
+        $assertMessage = "Pester result was '{0}'. Failed {1} test(s), {2} block(s) and {3} container(s). Aborting Build." -f
+            $DscTestObject.Result, $DscTestObject.FailedCount, $DscTestObject.FailedBlocksCount, $DscTestObject.FailedContainersCount
+
+        Assert-Build -Condition ($DscTestObject.Result -eq 'Passed') -Message $assertMessage
     }
 }


### PR DESCRIPTION
#### Pull Request (PR) description

`Fail_Build_If_HQRM_Tests_Failed` gated the build on `FailedCount` only:

```powershell
Assert-Build -Condition ($DscTestObject.FailedCount -eq 0) -Message ('Failed {0} tests. Aborting Build.' -f $DscTestObject.FailedCount)
```

`FailedCount` only counts failed **tests**. A Pester 5 discovery/container failure — for example a `Describe`/`Context` with an empty or `$null` `-ForEach`, or a parse error in a test file — fails during discovery and never runs a test. It sets `FailedContainersCount`/`FailedBlocksCount` and marks the run `Result` as `Failed`, but leaves `FailedCount` at `0`. The gate therefore passed and the build went green even though HQRM testing had actually failed. (This is the same class of failure that recently slipped through in dbachecks.)

This PR gates on the run `Result` instead, which already accounts for failed tests, blocks and containers:

```powershell
Assert-Build -Condition ($DscTestObject.Result -eq 'Passed') -Message $assertMessage
```

This mirrors the container-aware check already present in `Invoke_HQRM_Tests.build.ps1` (`if ($script:testResults.Result -eq 'Failed') { throw ... }`); the separate `Fail_Build_If_HQRM_Tests_Failed` gate task simply had not been updated to match. The repository already requires Pester `-MinimumVersion 5.1`, so `Result` is always present and no Pester 4 fallback is needed. The assertion message now also reports the failed block and container counts to make such failures easier to diagnose.

#### This Pull Request (PR) fixes the following issues

None

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
- [ ] Documentation added/updated in README.md.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/DscResource.Test/179)
<!-- Reviewable:end -->
